### PR TITLE
cicd 추가

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,99 @@
+name: value-together CICD
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  push_to_registry:
+    name: Push to aws container registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+
+      - name: make application-prod.yml
+        if: contains(github.ref, 'develop') || contains(github.ref, 'main')
+        run: |
+          cd ./src/main/resources
+          touch ./application-prod.yml
+          echo "${{ secrets.YML_PROD }}" > ./application-prod.yml
+        shell: bash
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        env:
+          SPRING_PROFILES_ACTIVE: prod
+        run: ./gradlew clean build -x test --stacktrace
+        shell: bash
+
+      - name: Docker build & push to prod
+        if: contains(github.ref, 'develop') || contains(github.ref, 'main')
+        run: |
+          docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build -t value-together -f ./infra/Dockerfile .
+          docker tag value-together:latest ${{ secrets.DOCKER_USER }}/value-together:latest
+          docker push ${{ secrets.DOCKER_USER }}/value-together:latest
+
+  pull_from_registry:
+    name: Connect server ssh and pull from container registry
+    needs: push_to_registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Github action IP
+        id: ip
+        uses: haythem/public-ip@v1.2
+
+      - name: Setting environment variables
+        run: |
+          echo "AWS_DEFAULT_REGION=ap-northeast-2" >> $GITHUB_ENV
+          echo "AWS_SG_NAME=launch-wizard-2" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Add Github Actions IP to Security group
+        run: |
+          aws ec2 authorize-security-group-ingress --group-name ${{ env.AWS_SG_NAME }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ap-northeast-2
+
+      - name: Deploy to prod
+        if: contains(github.ref, 'develop') || contains(github.ref, 'main')
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST_NAME }}
+          username: ${{ secrets.USER_NAME }}
+          key: ${{ secrets.AWS_PRIVATE_KEY }}
+          port: ${{ secrets.AWS_PORT }}
+          script: |
+            docker pull ${{ secrets.DOCKER_USER }}/value-together:latest
+            docker stop value-together
+            docker rm value-together
+            docker run -d --network value-together --name value-together -p 8080:8080 ${{ secrets.DOCKER_USER }}/value-together
+            if docker images -f "dangling=true" -q | grep . > /dev/null; then
+              docker rmi $(docker images -f "dangling=true" -q)
+            fi
+
+      - name: Remove Github Actions IP from security group
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name ${{ env.AWS_SG_NAME }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ap-northeast-2

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -1,0 +1,4 @@
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:17 AS builder
+ARG JAR_FILE=build/libs/value-together-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} vt.jar
+ENTRYPOINT ["java","-jar", "-Dspring.profiles.active=prod", "/vt.jar"]


### PR DESCRIPTION
## 개요
github actions를 활용한 cicd를 추가합니다.

## 작업사항
- Dockerfile을 추가합니다.
   - prod 환경에서 실행될 수 있도록 `spring.profiles.active=prod` 옵션을 추가합니다.
- prod 환경에서 build진행 후 docker hub에 이미지를 업로드합니다.
- ec2 인스턴스의 인바운드 규칙에 git actions의 ip를 추가합니다.
- ec2 인스턴스에 접속해서 docker hub의 image를 가져와서 실행합니다.
- ec2 인스턴스의 인바운드 규칙에 등록했던 git actions ip를 제거합니다.

## 관련 이슈
- close #2 
