### PR TITLE
checklist 저장 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ dependencies {
 
     // email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // h2
+    testImplementation 'com.h2database:h2:2.1.214'
+    compileOnly('com.h2database:h2:2.1.214')
 }
 
 spotless {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -63,3 +63,7 @@ endif::[]
 include::{snippets}/sample-controller-test/샘플_저장/auto-section.adoc[]
 include::{snippets}/sample-controller-test/샘플_전체_조회/auto-section.adoc[]
 include::{snippets}/sample-controller-test/샘플_단건_조회/auto-section.adoc[]
+
+== checklist API
+
+include::{snippets}/checklist-controller-test/checklist_저장/auto-section.adoc[]

--- a/src/main/java/com/vt/valuetogether/domain/checklist/controller/ChecklistController.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/controller/ChecklistController.java
@@ -1,0 +1,24 @@
+package com.vt.valuetogether.domain.checklist.controller;
+
+import com.vt.valuetogether.domain.checklist.dto.request.ChecklistSaveReq;
+import com.vt.valuetogether.domain.checklist.dto.response.ChecklistSaveRes;
+import com.vt.valuetogether.domain.checklist.service.ChecklistService;
+import com.vt.valuetogether.global.response.RestResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/checklists")
+@RequiredArgsConstructor
+public class ChecklistController {
+    private final ChecklistService checklistService;
+
+    @PostMapping
+    public RestResponse<ChecklistSaveRes> saveChecklist(
+            @RequestBody ChecklistSaveReq checklistSaveReq) {
+        return RestResponse.success(checklistService.saveChecklist(checklistSaveReq));
+    }
+}

--- a/src/main/java/com/vt/valuetogether/domain/checklist/dto/request/ChecklistSaveReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/dto/request/ChecklistSaveReq.java
@@ -1,0 +1,18 @@
+package com.vt.valuetogether.domain.checklist.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChecklistSaveReq {
+    // TODO ADD cardId
+    private String title;
+
+    @Builder
+    private ChecklistSaveReq(String title) {
+        this.title = title;
+    }
+}

--- a/src/main/java/com/vt/valuetogether/domain/checklist/dto/response/ChecklistSaveRes.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/dto/response/ChecklistSaveRes.java
@@ -1,0 +1,17 @@
+package com.vt.valuetogether.domain.checklist.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChecklistSaveRes {
+    private Long checklistId;
+
+    @Builder
+    private ChecklistSaveRes(Long checklistId) {
+        this.checklistId = checklistId;
+    }
+}

--- a/src/main/java/com/vt/valuetogether/domain/checklist/entity/Checklist.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/entity/Checklist.java
@@ -1,0 +1,32 @@
+package com.vt.valuetogether.domain.checklist.entity;
+
+import com.vt.valuetogether.domain.model.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tb_checklist")
+public class Checklist extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long checklistId;
+
+    private String title;
+
+    // TODO ADD Card
+
+    @Builder
+    private Checklist(Long checklistId, String title) {
+        this.checklistId = checklistId;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/vt/valuetogether/domain/checklist/repository/ChecklistRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/repository/ChecklistRepository.java
@@ -1,0 +1,9 @@
+package com.vt.valuetogether.domain.checklist.repository;
+
+import com.vt.valuetogether.domain.checklist.entity.Checklist;
+import org.springframework.data.repository.RepositoryDefinition;
+
+@RepositoryDefinition(domainClass = Checklist.class, idClass = Long.class)
+public interface ChecklistRepository {
+    Checklist save(Checklist checklist);
+}

--- a/src/main/java/com/vt/valuetogether/domain/checklist/service/ChecklistService.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/service/ChecklistService.java
@@ -1,0 +1,29 @@
+package com.vt.valuetogether.domain.checklist.service;
+
+import com.vt.valuetogether.domain.checklist.dto.request.ChecklistSaveReq;
+import com.vt.valuetogether.domain.checklist.dto.response.ChecklistSaveRes;
+import com.vt.valuetogether.domain.checklist.entity.Checklist;
+import com.vt.valuetogether.domain.checklist.repository.ChecklistRepository;
+import lombok.RequiredArgsConstructor;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChecklistService {
+    private final ChecklistRepository checklistRepository;
+
+    public ChecklistSaveRes saveChecklist(ChecklistSaveReq checklistSaveReq) {
+        // TODO ADD Card
+        return ChecklistServiceMapper.INSTANCE.toChecklistSaveRes(
+                checklistRepository.save(Checklist.builder().title(checklistSaveReq.getTitle()).build()));
+    }
+
+    @Mapper
+    public interface ChecklistServiceMapper {
+        ChecklistServiceMapper INSTANCE = Mappers.getMapper(ChecklistServiceMapper.class);
+
+        ChecklistSaveRes toChecklistSaveRes(Checklist checklist);
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,27 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;
+    username: sa
+    password:
+
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+      dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+    defer-datasource-initialization: true
+    sql:
+      init:
+        mode: always
+        encoding: UTF-8
+
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/src/test/java/com/vt/valuetogether/domain/BaseMvcTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/BaseMvcTest.java
@@ -47,9 +47,9 @@ public class BaseMvcTest {
                         .apply(
                                 MockMvcRestDocumentation.documentationConfiguration(restDocumentation)
                                         .uris()
-                                        .withScheme("http")
-                                        .withHost("localhost")
-                                        .withPort(8080)
+                                        .withScheme("https")
+                                        .withHost("whenwheres.com")
+                                        .withPort(443)
                                         .and()
                                         .snippets()
                                         .withDefaults(

--- a/src/test/java/com/vt/valuetogether/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/controller/ChecklistControllerTest.java
@@ -1,0 +1,39 @@
+package com.vt.valuetogether.domain.checklist.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.vt.valuetogether.domain.BaseMvcTest;
+import com.vt.valuetogether.domain.checklist.dto.request.ChecklistSaveReq;
+import com.vt.valuetogether.domain.checklist.dto.response.ChecklistSaveRes;
+import com.vt.valuetogether.domain.checklist.service.ChecklistService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(controllers = {ChecklistController.class})
+class ChecklistControllerTest extends BaseMvcTest {
+    @MockBean private ChecklistService checklistService;
+
+    @Test
+    @DisplayName("checklist 저장 테스트")
+    void checklist_저장() throws Exception {
+        Long checklistId = 1L;
+        String title = "title";
+        ChecklistSaveReq checklistSaveReq = ChecklistSaveReq.builder().title(title).build();
+        ChecklistSaveRes checklistSaveRes = ChecklistSaveRes.builder().checklistId(checklistId).build();
+        when(checklistService.saveChecklist(any())).thenReturn(checklistSaveRes);
+        this.mockMvc
+                .perform(
+                        post("/api/v1/checklists")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(checklistSaveReq)))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/vt/valuetogether/domain/checklist/repository/ChecklistRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/repository/ChecklistRepositoryTest.java
@@ -1,0 +1,31 @@
+package com.vt.valuetogether.domain.checklist.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.vt.valuetogether.domain.checklist.entity.Checklist;
+import com.vt.valuetogether.test.ChecklistTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ChecklistRepositoryTest implements ChecklistTest {
+    @Autowired private ChecklistRepository checklistRepository;
+
+    @Test
+    @DisplayName("checklist 저장 테스트")
+    void checklist_저장() {
+        // given
+
+        // when
+        Checklist checklist = checklistRepository.save(TEST_CHECKLIST);
+
+        // then
+        assertThat(checklist.getTitle()).isEqualTo(TEST_TITLE);
+    }
+}

--- a/src/test/java/com/vt/valuetogether/domain/checklist/service/ChecklistServiceTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/service/ChecklistServiceTest.java
@@ -1,0 +1,40 @@
+package com.vt.valuetogether.domain.checklist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vt.valuetogether.domain.checklist.dto.request.ChecklistSaveReq;
+import com.vt.valuetogether.domain.checklist.dto.response.ChecklistSaveRes;
+import com.vt.valuetogether.domain.checklist.repository.ChecklistRepository;
+import com.vt.valuetogether.test.ChecklistTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChecklistServiceTest implements ChecklistTest {
+    @InjectMocks private ChecklistService checklistService;
+
+    @Mock private ChecklistRepository checklistRepository;
+
+    @Test
+    @DisplayName("checklist 저장 테스트")
+    void checklist_저장() {
+        // given
+        String title = "title";
+        ChecklistSaveReq checklistSaveReq = ChecklistSaveReq.builder().title(title).build();
+        when(checklistRepository.save(any())).thenReturn(TEST_CHECKLIST);
+
+        // when
+        ChecklistSaveRes checklistSaveRes = checklistService.saveChecklist(checklistSaveReq);
+
+        // then
+        assertThat(checklistSaveRes.getChecklistId()).isEqualTo(TEST_CHECKLIST_ID);
+        verify(checklistRepository).save(any());
+    }
+}

--- a/src/test/java/com/vt/valuetogether/test/ChecklistTest.java
+++ b/src/test/java/com/vt/valuetogether/test/ChecklistTest.java
@@ -1,0 +1,13 @@
+package com.vt.valuetogether.test;
+
+import com.vt.valuetogether.domain.checklist.entity.Checklist;
+
+public interface ChecklistTest {
+
+    Long TEST_CHECKLIST_ID = 1L;
+
+    String TEST_TITLE = "title";
+
+    Checklist TEST_CHECKLIST =
+            Checklist.builder().checklistId(TEST_CHECKLIST_ID).title(TEST_TITLE).build();
+}


### PR DESCRIPTION
## 개요
checklist 저장 api를 추가합니다.

## 작업사항
- checklist 저장 api 추가
- 테스트 코드 추가
- adoc에 checklist api 추가

## 관련 이슈
- close #27 
