### PR TITLE
card 수정 api 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 
-application-prod.yml
-application-oauth.yml
+application**.yml

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -100,6 +100,7 @@ endif::[]
 == card API
 
 include::{snippets}/card-controller-test/card_저장/auto-section.adoc[]
+include::{snippets}/card-controller-test/card_수정/auto-section.adoc[]
 
 == checklist API
 

--- a/src/main/java/com/vt/valuetogether/domain/card/controller/CardController.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/controller/CardController.java
@@ -1,10 +1,14 @@
 package com.vt.valuetogether.domain.card.controller;
 
 import com.vt.valuetogether.domain.card.dto.request.CardSaveReq;
+import com.vt.valuetogether.domain.card.dto.request.CardUpdateReq;
 import com.vt.valuetogether.domain.card.dto.response.CardSaveRes;
+import com.vt.valuetogether.domain.card.dto.response.CardUpdateRes;
 import com.vt.valuetogether.domain.card.service.CardService;
 import com.vt.valuetogether.global.response.RestResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -19,7 +23,16 @@ public class CardController {
 
     @PostMapping
     public RestResponse<CardSaveRes> saveCard(
-            @RequestPart CardSaveReq cardSaveReq, @RequestPart MultipartFile multipartFile) {
+            @RequestPart CardSaveReq cardSaveReq,
+            @RequestPart(required = false) MultipartFile multipartFile) {
         return RestResponse.success(cardService.saveCard(cardSaveReq, multipartFile));
+    }
+
+    @PatchMapping
+    public RestResponse<CardUpdateRes> updateCard(
+            @RequestPart CardUpdateReq cardUpdateReq,
+            @RequestPart(required = false) MultipartFile multipartFile)
+            throws IOException {
+        return RestResponse.success(cardService.updateCard(cardUpdateReq, multipartFile));
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/controller/CardController.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/controller/CardController.java
@@ -6,7 +6,6 @@ import com.vt.valuetogether.domain.card.dto.response.CardSaveRes;
 import com.vt.valuetogether.domain.card.dto.response.CardUpdateRes;
 import com.vt.valuetogether.domain.card.service.CardService;
 import com.vt.valuetogether.global.response.RestResponse;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,8 +30,7 @@ public class CardController {
     @PatchMapping
     public RestResponse<CardUpdateRes> updateCard(
             @RequestPart CardUpdateReq cardUpdateReq,
-            @RequestPart(required = false) MultipartFile multipartFile)
-            throws IOException {
+            @RequestPart(required = false) MultipartFile multipartFile) {
         return RestResponse.success(cardService.updateCard(cardUpdateReq, multipartFile));
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardUpdateReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardUpdateReq.java
@@ -1,0 +1,24 @@
+package com.vt.valuetogether.domain.card.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CardUpdateReq {
+    private Long cardId;
+    private String name;
+    private String description;
+    private LocalDateTime deadline;
+
+    @Builder
+    private CardUpdateReq(Long cardId, String name, String description, LocalDateTime deadline) {
+        this.cardId = cardId;
+        this.name = name;
+        this.description = description;
+        this.deadline = deadline;
+    }
+}

--- a/src/main/java/com/vt/valuetogether/domain/card/dto/response/CardUpdateRes.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/dto/response/CardUpdateRes.java
@@ -1,0 +1,6 @@
+package com.vt.valuetogether.domain.card.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class CardUpdateRes {}

--- a/src/main/java/com/vt/valuetogether/domain/card/entity/Card.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/entity/Card.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tb_card")
 public class Card extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
@@ -10,4 +10,6 @@ public interface CardRepository {
 
     @Query(value = "select ifnull(max(c.sequence), 0) from Card c where c.categoryId=:categoryId")
     Double getMaxSequence(Long categoryId);
+
+    Card findByCardId(Long cardId);
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/service/CardService.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/CardService.java
@@ -1,9 +1,13 @@
 package com.vt.valuetogether.domain.card.service;
 
 import com.vt.valuetogether.domain.card.dto.request.CardSaveReq;
+import com.vt.valuetogether.domain.card.dto.request.CardUpdateReq;
 import com.vt.valuetogether.domain.card.dto.response.CardSaveRes;
+import com.vt.valuetogether.domain.card.dto.response.CardUpdateRes;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface CardService {
     CardSaveRes saveCard(CardSaveReq cardSaveReq, MultipartFile multipartFile);
+
+    CardUpdateRes updateCard(CardUpdateReq cardUpdateReq, MultipartFile multipartFile);
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImpl.java
@@ -3,11 +3,14 @@ package com.vt.valuetogether.domain.card.service.impl;
 import static com.vt.valuetogether.infra.s3.S3Util.FilePath.CARD;
 
 import com.vt.valuetogether.domain.card.dto.request.CardSaveReq;
+import com.vt.valuetogether.domain.card.dto.request.CardUpdateReq;
 import com.vt.valuetogether.domain.card.dto.response.CardSaveRes;
+import com.vt.valuetogether.domain.card.dto.response.CardUpdateRes;
 import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.domain.card.repository.CardRepository;
 import com.vt.valuetogether.domain.card.service.CardService;
 import com.vt.valuetogether.domain.card.service.CardServiceMapper;
+import com.vt.valuetogether.global.validator.CardValidator;
 import com.vt.valuetogether.infra.s3.S3Util;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -38,5 +41,34 @@ public class CardServiceImpl implements CardService {
 
     private Double getMaxSequence(Long categoryId) {
         return cardRepository.getMaxSequence(categoryId) + NEXT_SEQUENCE;
+    }
+
+    @Override
+    public CardUpdateRes updateCard(CardUpdateReq cardUpdateReq, MultipartFile multipartFile) {
+        Card prevCard = cardRepository.findByCardId(cardUpdateReq.getCardId());
+        CardValidator.validate(prevCard);
+        deleteFile(prevCard.getFileUrl());
+        String fileUrl = null;
+        if (multipartFile != null && !multipartFile.isEmpty()) {
+            fileUrl = s3Util.uploadFile(multipartFile, CARD);
+        }
+        cardRepository.save(
+                Card.builder()
+                        .cardId(prevCard.getCardId())
+                        .name(cardUpdateReq.getName())
+                        .description(cardUpdateReq.getDescription())
+                        .fileUrl(fileUrl)
+                        .sequence(prevCard.getSequence())
+                        .deadline(cardUpdateReq.getDeadline())
+                        .categoryId(prevCard.getCategoryId())
+                        .build());
+        return new CardUpdateRes();
+    }
+
+    private void deleteFile(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            return;
+        }
+        s3Util.deleteFile(fileUrl, CARD);
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImpl.java
@@ -14,6 +14,7 @@ import com.vt.valuetogether.global.validator.CardValidator;
 import com.vt.valuetogether.infra.s3.S3Util;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -24,6 +25,7 @@ public class CardServiceImpl implements CardService {
     private final Double NEXT_SEQUENCE = 1.0;
 
     @Override
+    @Transactional
     public CardSaveRes saveCard(CardSaveReq cardSaveReq, MultipartFile multipartFile) {
         Double sequence = getMaxSequence(cardSaveReq.getCategoryId());
         String fileUrl = s3Util.uploadFile(multipartFile, CARD);
@@ -44,6 +46,7 @@ public class CardServiceImpl implements CardService {
     }
 
     @Override
+    @Transactional
     public CardUpdateRes updateCard(CardUpdateReq cardUpdateReq, MultipartFile multipartFile) {
         Card prevCard = cardRepository.findByCardId(cardUpdateReq.getCardId());
         CardValidator.validate(prevCard);

--- a/src/main/java/com/vt/valuetogether/global/meta/ResultCode.java
+++ b/src/main/java/com/vt/valuetogether/global/meta/ResultCode.java
@@ -42,6 +42,7 @@ public enum ResultCode {
     // 카테고리 4000번대
 
     // 카드 5000번대
+    NOT_FOUND_CARD(HttpStatus.NOT_FOUND, 5000, "카드 정보를 찾을 수 없습니다."),
 
     // 작업자 6000번대
 

--- a/src/main/java/com/vt/valuetogether/global/validator/CardValidator.java
+++ b/src/main/java/com/vt/valuetogether/global/validator/CardValidator.java
@@ -1,0 +1,18 @@
+package com.vt.valuetogether.global.validator;
+
+import static com.vt.valuetogether.global.meta.ResultCode.NOT_FOUND_CARD;
+
+import com.vt.valuetogether.domain.card.entity.Card;
+import com.vt.valuetogether.global.exception.GlobalException;
+
+public class CardValidator {
+    public static void validate(Card card) {
+        if (isNullCard(card)) {
+            throw new GlobalException(NOT_FOUND_CARD);
+        }
+    }
+
+    private static boolean isNullCard(Card card) {
+        return card == null;
+    }
+}

--- a/src/test/java/com/vt/valuetogether/domain/card/controller/CardControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/controller/CardControllerTest.java
@@ -12,6 +12,7 @@ import com.vt.valuetogether.domain.BaseMvcTest;
 import com.vt.valuetogether.domain.card.dto.request.CardSaveReq;
 import com.vt.valuetogether.domain.card.dto.request.CardUpdateReq;
 import com.vt.valuetogether.domain.card.dto.response.CardSaveRes;
+import com.vt.valuetogether.domain.card.dto.response.CardUpdateRes;
 import com.vt.valuetogether.domain.card.service.CardService;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -96,8 +97,8 @@ class CardControllerTest extends BaseMvcTest {
                 new MockMultipartFile(
                         "cardUpdateReq", "json", "application/json", json.getBytes(StandardCharsets.UTF_8));
 
-        CardSaveRes cardSaveRes = CardSaveRes.builder().cardId(cardId).build();
-        when(cardService.saveCard(any(), any())).thenReturn(cardSaveRes);
+        CardUpdateRes cardUpdateRes = new CardUpdateRes();
+        when(cardService.updateCard(any(), any())).thenReturn(cardUpdateRes);
         this.mockMvc
                 .perform(multipart(PATCH, "/api/v1/cards").file(multipartFile).file(req))
                 .andDo(print())

--- a/src/test/java/com/vt/valuetogether/domain/card/controller/CardControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/controller/CardControllerTest.java
@@ -2,6 +2,7 @@ package com.vt.valuetogether.domain.card.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.PATCH;
 import static org.springframework.http.MediaType.IMAGE_JPEG;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.vt.valuetogether.domain.BaseMvcTest;
 import com.vt.valuetogether.domain.card.dto.request.CardSaveReq;
+import com.vt.valuetogether.domain.card.dto.request.CardUpdateReq;
 import com.vt.valuetogether.domain.card.dto.response.CardSaveRes;
 import com.vt.valuetogether.domain.card.service.CardService;
 import java.nio.charset.StandardCharsets;
@@ -29,11 +31,17 @@ class CardControllerTest extends BaseMvcTest {
     @DisplayName("card 저장 테스트")
     void card_저장() throws Exception {
         Long cardId = 1L;
+        Long categoryId = 1L;
         String name = "name";
         String description = "desc";
         LocalDateTime deadline = LocalDateTime.now();
         CardSaveReq cardSaveReq =
-                CardSaveReq.builder().name(name).description(description).deadline(deadline).build();
+                CardSaveReq.builder()
+                        .categoryId(categoryId)
+                        .name(name)
+                        .description(description)
+                        .deadline(deadline)
+                        .build();
 
         String imageUrl = "images/image1.jpg";
         Resource fileResource = new ClassPathResource(imageUrl);
@@ -54,6 +62,44 @@ class CardControllerTest extends BaseMvcTest {
         when(cardService.saveCard(any(), any())).thenReturn(cardSaveRes);
         this.mockMvc
                 .perform(multipart("/api/v1/cards").file(multipartFile).file(req))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("card 수정 테스트")
+    void card_수정() throws Exception {
+        Long cardId = 1L;
+        String name = "name";
+        String description = "desc";
+        LocalDateTime deadline = LocalDateTime.now();
+        CardUpdateReq cardUpdateReq =
+                CardUpdateReq.builder()
+                        .cardId(cardId)
+                        .name(name)
+                        .description(description)
+                        .deadline(deadline)
+                        .build();
+
+        String imageUrl = "images/image1.jpg";
+        Resource fileResource = new ClassPathResource(imageUrl);
+        MockMultipartFile file =
+                new MockMultipartFile(
+                        "image1",
+                        fileResource.getFilename(),
+                        IMAGE_JPEG.getType(),
+                        fileResource.getInputStream());
+        MockMultipartFile multipartFile =
+                new MockMultipartFile("multipartFile", "orig", "multipart/form-data", file.getBytes());
+        String json = objectMapper.writeValueAsString(cardUpdateReq);
+        MockMultipartFile req =
+                new MockMultipartFile(
+                        "cardUpdateReq", "json", "application/json", json.getBytes(StandardCharsets.UTF_8));
+
+        CardSaveRes cardSaveRes = CardSaveRes.builder().cardId(cardId).build();
+        when(cardService.saveCard(any(), any())).thenReturn(cardSaveRes);
+        this.mockMvc
+                .perform(multipart(PATCH, "/api/v1/cards").file(multipartFile).file(req))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
@@ -48,7 +48,7 @@ class CardRepositoryTest implements CardTest {
     }
 
     @Test
-    @DisplayName("id로 card 조회")
+    @DisplayName("id로 card 조회 테스트")
     void id_card_조회() {
         // given
         Card saveCard = cardRepository.save(TEST_CARD);

--- a/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
@@ -46,4 +46,21 @@ class CardRepositoryTest implements CardTest {
         // then
         assertThat(maxSequence).isEqualTo(saveCard.getSequence());
     }
+
+    @Test
+    @DisplayName("id로 card 조회")
+    void id_card_조회() {
+        // given
+        Card saveCard = cardRepository.save(TEST_CARD);
+
+        // when
+        Card card = cardRepository.findByCardId(saveCard.getCardId());
+
+        // then
+        assertThat(card.getName()).isEqualTo(saveCard.getName());
+        assertThat(card.getDescription()).isEqualTo(saveCard.getDescription());
+        assertThat(card.getFileUrl()).isEqualTo(saveCard.getFileUrl());
+        assertThat(card.getSequence()).isEqualTo(saveCard.getSequence());
+        assertThat(card.getDeadline()).isEqualTo(saveCard.getDeadline());
+    }
 }

--- a/src/test/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.IMAGE_JPEG;
 
 import com.vt.valuetogether.domain.card.dto.request.CardSaveReq;
+import com.vt.valuetogether.domain.card.dto.request.CardUpdateReq;
 import com.vt.valuetogether.domain.card.repository.CardRepository;
 import com.vt.valuetogether.infra.s3.S3Util;
 import com.vt.valuetogether.test.CardTest;
@@ -60,6 +61,43 @@ class CardServiceImplTest implements CardTest {
 
         // then
         verify(cardRepository).getMaxSequence(any());
+        verify(cardRepository).save(any());
+        verify(s3Util).uploadFile(any(), any());
+    }
+
+    @Test
+    @DisplayName("card 수정 테스트")
+    void card_수정() throws Exception {
+        // given
+        Long cardId = 1L;
+        String name = "updatedName";
+        String description = "updatedDesc";
+        LocalDateTime deadline = LocalDateTime.now();
+        CardUpdateReq cardUpdateReq =
+                CardUpdateReq.builder()
+                        .cardId(cardId)
+                        .name(name)
+                        .description(description)
+                        .deadline(deadline)
+                        .build();
+
+        String fileUrl = "images/image1.jpg";
+        Resource fileResource = new ClassPathResource(fileUrl);
+        MockMultipartFile multipartFile =
+                new MockMultipartFile(
+                        "image1",
+                        fileResource.getFilename(),
+                        IMAGE_JPEG.getType(),
+                        fileResource.getInputStream());
+        when(cardRepository.findByCardId(any())).thenReturn(TEST_CARD);
+        when(cardRepository.save(any())).thenReturn(TEST_UPDATED_CARD);
+        when(s3Util.uploadFile(any(), any())).thenReturn(TEST_FILE_URL);
+
+        // when
+        cardService.updateCard(cardUpdateReq, multipartFile);
+
+        // then
+        verify(cardRepository).findByCardId(any());
         verify(cardRepository).save(any());
         verify(s3Util).uploadFile(any(), any());
     }

--- a/src/test/java/com/vt/valuetogether/test/CardTest.java
+++ b/src/test/java/com/vt/valuetogether/test/CardTest.java
@@ -14,6 +14,11 @@ public interface CardTest {
     LocalDateTime TEST_DEADLINE = LocalDateTime.now();
     Long categoryId = 1L;
 
+    String TEST_UPDATED_NAME = "updatedName";
+    String TEST_UPDATED_DESCRIPTION = "updatedDescription";
+    String TEST_UPDATED_FILE_URL = "updatedUrl";
+    LocalDateTime TEST_UPDATED_DEADLINE = LocalDateTime.now().plusDays(1L);
+
     Card TEST_CARD =
             Card.builder()
                     .cardId(TEST_CARD_ID)
@@ -22,6 +27,17 @@ public interface CardTest {
                     .fileUrl(TEST_FILE_URL)
                     .sequence(TEST_SEQUENCE)
                     .deadline(TEST_DEADLINE)
+                    .categoryId(categoryId)
+                    .build();
+
+    Card TEST_UPDATED_CARD =
+            Card.builder()
+                    .cardId(TEST_CARD_ID)
+                    .name(TEST_UPDATED_NAME)
+                    .description(TEST_UPDATED_DESCRIPTION)
+                    .fileUrl(TEST_UPDATED_FILE_URL)
+                    .sequence(TEST_SEQUENCE)
+                    .deadline(TEST_UPDATED_DEADLINE)
                     .categoryId(categoryId)
                     .build();
 }


### PR DESCRIPTION
## 개요
card 수정 api를 추가합니다.

## 작업사항
- card update api 추가
- 테스트코드 추가
- restdocs 추가
- gitignore에 `application**.yml` 추가

## 관련 이슈
- close #54 
