### PR TITLE
프로필 조회 api, 테스트 코드 추가

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/user/controller/UserController.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/controller/UserController.java
@@ -14,9 +14,9 @@ import com.vt.valuetogether.domain.user.dto.response.UserVerifyEmailRes;
 import com.vt.valuetogether.domain.user.dto.response.UserVerifyPasswordRes;
 import com.vt.valuetogether.domain.user.service.UserService;
 import com.vt.valuetogether.global.response.RestResponse;
-import com.vt.valuetogether.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,12 +35,12 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/email")
+    @PostMapping("/signup/email")
     public RestResponse<UserVerifyEmailRes> sendEmail(@RequestBody UserVerifyEmailReq req) {
         return RestResponse.success(userService.sendEmail(req));
     }
 
-    @GetMapping("/confirm-email")
+    @GetMapping("/signup/email/check")
     public RestResponse<UserConfirmEmailRes> confirmEmail(
             @RequestParam(name = "email") String email, @RequestParam(name = "authCode") String code) {
         return RestResponse.success(userService.confirmEmail(email, code));
@@ -59,9 +59,8 @@ public class UserController {
 
     @PostMapping("/password/verify")
     public RestResponse<UserVerifyPasswordRes> verifyPassword(
-            @RequestBody UserVerifyPasswordReq req,
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        req.setUserId(userDetails.getUser().getUserId());
+            @RequestBody UserVerifyPasswordReq req, @AuthenticationPrincipal UserDetails userDetails) {
+        req.setUsername(userDetails.getUsername());
         return RestResponse.success(userService.verifyPassword(req));
     }
 
@@ -69,8 +68,8 @@ public class UserController {
     public RestResponse<UserUpdateProfileRes> updateProfile(
             @RequestPart(name = "data") UserUpdateProfileReq req,
             @RequestPart(name = "image", required = false) MultipartFile multipartfile,
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        req.setUserId(userDetails.getUser().getUserId());
+            @AuthenticationPrincipal UserDetails userDetails) {
+        req.setUsername(userDetails.getUsername());
         return RestResponse.success(userService.updateProfile(req, multipartfile));
     }
 

--- a/src/main/java/com/vt/valuetogether/domain/user/controller/UserController.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.vt.valuetogether.domain.user.dto.request.UserVerifyEmailReq;
 import com.vt.valuetogether.domain.user.dto.request.UserVerifyPasswordReq;
 import com.vt.valuetogether.domain.user.dto.response.UserCheckDuplicateUsernameRes;
 import com.vt.valuetogether.domain.user.dto.response.UserConfirmEmailRes;
+import com.vt.valuetogether.domain.user.dto.response.UserGetProfileRes;
 import com.vt.valuetogether.domain.user.dto.response.UserSignupRes;
 import com.vt.valuetogether.domain.user.dto.response.UserUpdateProfileRes;
 import com.vt.valuetogether.domain.user.dto.response.UserVerifyEmailRes;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -70,5 +72,10 @@ public class UserController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         req.setUserId(userDetails.getUser().getUserId());
         return RestResponse.success(userService.updateProfile(req, multipartfile));
+    }
+
+    @GetMapping("/{userId}")
+    public RestResponse<UserGetProfileRes> getProfile(@PathVariable Long userId) {
+        return RestResponse.success(userService.getProfile(userId));
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/user/dto/request/UserUpdateProfileReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/dto/request/UserUpdateProfileReq.java
@@ -10,14 +10,15 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserUpdateProfileReq {
-    private Long userId;
+    private String preUsername;
     private String username;
     private String password;
     private String introduce;
 
     @Builder
-    private UserUpdateProfileReq(Long userId, String username, String password, String introduce) {
-        this.userId = userId;
+    private UserUpdateProfileReq(
+            String preUsername, String username, String password, String introduce) {
+        this.preUsername = preUsername;
         this.username = username;
         this.password = password;
         this.introduce = introduce;

--- a/src/main/java/com/vt/valuetogether/domain/user/dto/request/UserVerifyPasswordReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/dto/request/UserVerifyPasswordReq.java
@@ -10,12 +10,12 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserVerifyPasswordReq {
-    private Long userId;
+    private String username;
     private String password;
 
     @Builder
-    private UserVerifyPasswordReq(Long userId, String password) {
-        this.userId = userId;
+    private UserVerifyPasswordReq(String username, String password) {
+        this.username = username;
         this.password = password;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/user/dto/response/UserGetProfileRes.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/dto/response/UserGetProfileRes.java
@@ -1,0 +1,31 @@
+package com.vt.valuetogether.domain.user.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserGetProfileRes {
+
+    private Long userId;
+
+    private String username;
+
+    private String email;
+
+    private String introduce;
+
+    private String profileImageUrl;
+
+    @Builder
+    private UserGetProfileRes(
+            Long userId, String username, String email, String introduce, String profileImageUrl) {
+        this.userId = userId;
+        this.username = username;
+        this.email = email;
+        this.introduce = introduce;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/com/vt/valuetogether/domain/user/service/UserService.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.vt.valuetogether.domain.user.dto.request.UserVerifyEmailReq;
 import com.vt.valuetogether.domain.user.dto.request.UserVerifyPasswordReq;
 import com.vt.valuetogether.domain.user.dto.response.UserCheckDuplicateUsernameRes;
 import com.vt.valuetogether.domain.user.dto.response.UserConfirmEmailRes;
+import com.vt.valuetogether.domain.user.dto.response.UserGetProfileRes;
 import com.vt.valuetogether.domain.user.dto.response.UserSignupRes;
 import com.vt.valuetogether.domain.user.dto.response.UserUpdateProfileRes;
 import com.vt.valuetogether.domain.user.dto.response.UserVerifyEmailRes;
@@ -25,4 +26,6 @@ public interface UserService {
     UserVerifyPasswordRes verifyPassword(UserVerifyPasswordReq req);
 
     UserUpdateProfileRes updateProfile(UserUpdateProfileReq req, MultipartFile multipartFile);
+
+    UserGetProfileRes getProfile(Long userId);
 }

--- a/src/main/java/com/vt/valuetogether/domain/user/service/UserServiceMapper.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/service/UserServiceMapper.java
@@ -1,9 +1,13 @@
 package com.vt.valuetogether.domain.user.service;
 
+import com.vt.valuetogether.domain.user.dto.response.UserGetProfileRes;
+import com.vt.valuetogether.domain.user.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
 public interface UserServiceMapper {
     UserServiceMapper INSTANCE = Mappers.getMapper(UserServiceMapper.class);
+
+    UserGetProfileRes toUserGetProfileRes(User user);
 }

--- a/src/main/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImpl.java
@@ -7,6 +7,7 @@ import com.vt.valuetogether.domain.user.dto.request.UserVerifyEmailReq;
 import com.vt.valuetogether.domain.user.dto.request.UserVerifyPasswordReq;
 import com.vt.valuetogether.domain.user.dto.response.UserCheckDuplicateUsernameRes;
 import com.vt.valuetogether.domain.user.dto.response.UserConfirmEmailRes;
+import com.vt.valuetogether.domain.user.dto.response.UserGetProfileRes;
 import com.vt.valuetogether.domain.user.dto.response.UserSignupRes;
 import com.vt.valuetogether.domain.user.dto.response.UserUpdateProfileRes;
 import com.vt.valuetogether.domain.user.dto.response.UserVerifyEmailRes;
@@ -17,6 +18,7 @@ import com.vt.valuetogether.domain.user.entity.Role;
 import com.vt.valuetogether.domain.user.entity.User;
 import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.domain.user.service.UserService;
+import com.vt.valuetogether.domain.user.service.UserServiceMapper;
 import com.vt.valuetogether.global.validator.S3Validator;
 import com.vt.valuetogether.global.validator.UserValidator;
 import com.vt.valuetogether.infra.mail.MailUtil;
@@ -130,6 +132,13 @@ public class UserServiceImpl implements UserService {
                         .build());
 
         return new UserUpdateProfileRes();
+    }
+
+    @Override
+    public UserGetProfileRes getProfile(Long userId) {
+        User user = getUser(userId);
+
+        return UserServiceMapper.INSTANCE.toUserGetProfileRes(user);
     }
 
     private void checkAuthorizedEmail(String email) {

--- a/src/main/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImpl.java
@@ -94,7 +94,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserVerifyPasswordRes verifyPassword(UserVerifyPasswordReq req) {
-        User savedUser = getUser(req.getUserId());
+        User savedUser = getUser(req.getUsername());
         boolean isMatched = passwordEncoder.matches(req.getPassword(), savedUser.getPassword());
 
         return UserVerifyPasswordRes.builder().isMatched(isMatched).build();
@@ -104,7 +104,7 @@ public class UserServiceImpl implements UserService {
     public UserUpdateProfileRes updateProfile(UserUpdateProfileReq req, MultipartFile multipartFile) {
 
         UserValidator.validate(req);
-        User savedUser = getUser(req.getUserId());
+        User savedUser = getUser(req.getPreUsername());
 
         String imageUrl = savedUser.getProfileImageUrl();
         if (!imageUrl.equals(DEFAULT_PROFILE_IMAGE_URL)) {
@@ -134,7 +134,8 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserGetProfileRes getProfile(Long userId) {
-        User user = getUser(userId);
+        User user = userRepository.findByUserId(userId);
+        UserValidator.validate(user);
 
         return UserServiceMapper.INSTANCE.toUserGetProfileRes(user);
     }
@@ -144,8 +145,8 @@ public class UserServiceImpl implements UserService {
         UserValidator.checkAuthorizedEmail(authEmail.isChecked());
     }
 
-    private User getUser(Long userId) {
-        User user = userRepository.findByUserId(userId);
+    private User getUser(String username) {
+        User user = userRepository.findByUsername(username);
         UserValidator.validate(user);
         return user;
     }

--- a/src/main/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImpl.java
@@ -87,9 +87,10 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserCheckDuplicateUsernameRes checkDuplicateUsername(UserCheckDuplicateUsernameReq req) {
         UserValidator.validate(req);
-        boolean isDuplicated = userRepository.existsByUsername(req.getUsername());
 
-        return UserCheckDuplicateUsernameRes.builder().isDuplicated(isDuplicated).build();
+        return UserCheckDuplicateUsernameRes.builder()
+                .isDuplicated(userRepository.existsByUsername(req.getUsername()))
+                .build();
     }
 
     @Override

--- a/src/main/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImpl.java
@@ -66,8 +66,7 @@ public class UserServiceImpl implements UserService {
     public UserSignupRes signup(UserSignupReq req) {
         UserValidator.validate(req);
 
-        User user = userRepository.findByUsername(req.getUsername());
-        UserValidator.checkDuplicatedUsername(user);
+        UserValidator.checkDuplicatedUsername(userRepository.existsByUsername(req.getUsername()));
 
         checkAuthorizedEmail(req.getEmail());
 
@@ -88,8 +87,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserCheckDuplicateUsernameRes checkDuplicateUsername(UserCheckDuplicateUsernameReq req) {
         UserValidator.validate(req);
-        User user = userRepository.findByUsername(req.getUsername());
-        boolean isDuplicated = (user != null);
+        boolean isDuplicated = userRepository.existsByUsername(req.getUsername());
 
         return UserCheckDuplicateUsernameRes.builder().isDuplicated(isDuplicated).build();
     }
@@ -112,7 +110,7 @@ public class UserServiceImpl implements UserService {
         if (!imageUrl.equals(DEFAULT_PROFILE_IMAGE_URL)) {
             s3Util.deleteFile(imageUrl, FilePath.PROFILE);
         }
-        if (multipartFile.isEmpty()) {
+        if (multipartFile == null || multipartFile.isEmpty()) {
             imageUrl = DEFAULT_PROFILE_IMAGE_URL;
         } else {
             S3Validator.isProfileImageFile(multipartFile);

--- a/src/main/java/com/vt/valuetogether/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/vt/valuetogether/global/config/WebSecurityConfig.java
@@ -79,8 +79,9 @@ public class WebSecurityConfig {
                         authorizeHttpRequests
                                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                                 .permitAll() // resources 접근 허용 설정
-                                .requestMatchers("/api/v1/users/**")
-                                .permitAll() // '/api/v1/users/'로 시작하는 요청 모두 접근 허가
+                                .requestMatchers(
+                                        "/api/v1/users/email", "/api/v1/users/signup", "/api/v1/users/confirm-email")
+                                .permitAll()
                                 .anyRequest()
                                 .authenticated() // 그 외 모든 요청 인증처리
                 );

--- a/src/main/java/com/vt/valuetogether/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/vt/valuetogether/global/config/WebSecurityConfig.java
@@ -85,8 +85,7 @@ public class WebSecurityConfig {
                         authorizeHttpRequests
                                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                                 .permitAll() // resources 접근 허용 설정
-                                .requestMatchers(
-                                        "/api/v1/users/email", "/api/v1/users/signup", "/api/v1/users/confirm-email")
+                                .requestMatchers("/api/v1/users/signup/**")
                                 .permitAll() // 회원가입 관련 API만 접근 허용
                                 .anyRequest()
                                 .authenticated() // 그 외 모든 요청 인증처리

--- a/src/main/java/com/vt/valuetogether/global/validator/UserValidator.java
+++ b/src/main/java/com/vt/valuetogether/global/validator/UserValidator.java
@@ -62,8 +62,8 @@ public class UserValidator {
         }
     }
 
-    public static void checkDuplicatedUsername(User user) {
-        if (!checkIsNull(user)) {
+    public static void checkDuplicatedUsername(boolean isDuplicated) {
+        if (isDuplicated) {
             throw new GlobalException(DUPLICATED_USERNAME);
         }
     }

--- a/src/main/java/com/vt/valuetogether/infra/mail/MailUtil.java
+++ b/src/main/java/com/vt/valuetogether/infra/mail/MailUtil.java
@@ -25,7 +25,7 @@ public class MailUtil {
 
     private final JavaMailSender mailSender;
     private final EmailAuthService emailService;
-    private static final String EMAIL_LINK = "http://localhost:8080/api/v1/users/confirm-email?";
+    private static final String EMAIL_LINK = "http://localhost:8080/api/v1/users/signup/email/check?";
     private static final String PATH_AND = "&";
     private static final String PATH_KEY_EMAIL = "email=";
     private static final String PATH_KEY_CODE = "authCode=";

--- a/src/test/java/com/vt/valuetogether/domain/BaseMvcTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/BaseMvcTest.java
@@ -1,9 +1,15 @@
 package com.vt.valuetogether.domain;
 
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
 import capital.scalable.restdocs.AutoDocumentation;
 import capital.scalable.restdocs.jackson.JacksonResultHandlers;
 import capital.scalable.restdocs.response.ResponseModifyingPreprocessors;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vt.valuetogether.global.MockSpringSecurityFilter;
+import com.vt.valuetogether.global.security.UserDetailsImpl;
+import com.vt.valuetogether.test.UserTest;
+import java.security.Principal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -14,6 +20,8 @@ import org.springframework.restdocs.cli.CliDocumentation;
 import org.springframework.restdocs.http.HttpDocumentation;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.operation.preprocess.Preprocessors;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -21,10 +29,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 @ExtendWith({RestDocumentationExtension.class, MockitoExtension.class, SpringExtension.class})
-public class BaseMvcTest {
+public class BaseMvcTest implements UserTest {
 
     @Autowired protected ObjectMapper objectMapper;
     protected MockMvc mockMvc;
+    protected Principal mockPrincipal;
     @Autowired private WebApplicationContext context;
 
     @BeforeEach
@@ -44,6 +53,7 @@ public class BaseMvcTest {
                                                 ResponseModifyingPreprocessors.replaceBinaryContent(),
                                                 ResponseModifyingPreprocessors.limitJsonArrayLength(objectMapper),
                                                 Preprocessors.prettyPrint())))
+                        .apply(springSecurity(new MockSpringSecurityFilter()))
                         .apply(
                                 MockMvcRestDocumentation.documentationConfiguration(restDocumentation)
                                         .uris()
@@ -64,5 +74,9 @@ public class BaseMvcTest {
                                                 AutoDocumentation.methodAndPath(),
                                                 AutoDocumentation.section()))
                         .build();
+        UserDetails testUserDetails = new UserDetailsImpl(TEST_USER);
+        mockPrincipal =
+                new UsernamePasswordAuthenticationToken(
+                        testUserDetails, "", testUserDetails.getAuthorities());
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,245 @@
+package com.vt.valuetogether.domain.user.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.vt.valuetogether.domain.BaseMvcTest;
+import com.vt.valuetogether.domain.user.dto.request.UserCheckDuplicateUsernameReq;
+import com.vt.valuetogether.domain.user.dto.request.UserSignupReq;
+import com.vt.valuetogether.domain.user.dto.request.UserUpdateProfileReq;
+import com.vt.valuetogether.domain.user.dto.request.UserVerifyEmailReq;
+import com.vt.valuetogether.domain.user.dto.request.UserVerifyPasswordReq;
+import com.vt.valuetogether.domain.user.dto.response.UserCheckDuplicateUsernameRes;
+import com.vt.valuetogether.domain.user.dto.response.UserConfirmEmailRes;
+import com.vt.valuetogether.domain.user.dto.response.UserGetProfileRes;
+import com.vt.valuetogether.domain.user.dto.response.UserSignupRes;
+import com.vt.valuetogether.domain.user.dto.response.UserUpdateProfileRes;
+import com.vt.valuetogether.domain.user.dto.response.UserVerifyEmailRes;
+import com.vt.valuetogether.domain.user.dto.response.UserVerifyPasswordRes;
+import com.vt.valuetogether.domain.user.service.UserService;
+import com.vt.valuetogether.global.MockSpringSecurityFilter;
+import com.vt.valuetogether.global.config.WebSecurityConfig;
+import com.vt.valuetogether.global.security.UserDetailsImpl;
+import com.vt.valuetogether.test.UserTest;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebMvcTest(
+        controllers = {UserController.class},
+        excludeFilters = {
+            @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class)
+        })
+class UserControllerTest extends BaseMvcTest implements UserTest {
+
+    @MockBean private UserService userService;
+
+    private MockMvc mvc;
+
+    private Principal mockPrincipal;
+
+    @Autowired private WebApplicationContext context;
+
+    @BeforeEach
+    public void setup() {
+        mvc =
+                MockMvcBuilders.webAppContextSetup(context)
+                        .apply(springSecurity(new MockSpringSecurityFilter()))
+                        .build();
+    }
+
+    private void mockUserSetup() {
+        UserDetailsImpl testUserDetails = new UserDetailsImpl(TEST_USER);
+        mockPrincipal =
+                new UsernamePasswordAuthenticationToken(
+                        testUserDetails, "", testUserDetails.getAuthorities());
+    }
+
+    @Test
+    @DisplayName("이메일 전송 api 테스트")
+    void sendEmailTest() throws Exception {
+        // given
+        UserVerifyEmailReq req = UserVerifyEmailReq.builder().email(TEST_USER_EMAIL).build();
+        UserVerifyEmailRes res = new UserVerifyEmailRes();
+        when(userService.sendEmail(req)).thenReturn(res);
+
+        // when - then
+        mvc.perform(
+                        post("/api/v1/users/email")
+                                .content(objectMapper.writeValueAsString(req))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("이메일 링크 확인 api 테스트")
+    void confirmEmailTest() throws Exception {
+        // given
+        String email = "abcd@ab.com";
+        String code = "abdEfs";
+
+        UserConfirmEmailRes res = UserConfirmEmailRes.builder().email(email).build();
+        when(userService.confirmEmail(email, code)).thenReturn(res);
+
+        MultiValueMap<String, String> info = new LinkedMultiValueMap<>();
+
+        info.add("email", email);
+        info.add("authCode", code);
+
+        // when - then
+        mvc.perform(get("/api/v1/users/confirm-email").params(info))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원가입 api 테스트")
+    void signupTest() throws Exception {
+        // given
+        UserSignupReq req =
+                UserSignupReq.builder()
+                        .username(TEST_USER_NAME)
+                        .password(TEST_USER_PASSWORD)
+                        .email(TEST_USER_EMAIL)
+                        .build();
+        UserSignupRes res = new UserSignupRes();
+        when(userService.signup(req)).thenReturn(res);
+
+        // when - then
+        mvc.perform(
+                        post("/api/v1/users/signup")
+                                .content(objectMapper.writeValueAsString(req))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("username 중복확인 api 테스트")
+    void confirmUsernameTest() throws Exception {
+        // given
+        UserCheckDuplicateUsernameReq req =
+                UserCheckDuplicateUsernameReq.builder().username(TEST_USER_NAME).build();
+        UserCheckDuplicateUsernameRes res =
+                UserCheckDuplicateUsernameRes.builder().isDuplicated(true).build();
+        when(userService.checkDuplicateUsername(req)).thenReturn(res);
+
+        // when - then
+        mvc.perform(
+                        post("/api/v1/users/username")
+                                .content(objectMapper.writeValueAsString(req))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("password 확인 api 테스트")
+    void verifyPasswordTest() throws Exception {
+        // given
+        mockUserSetup();
+        UserVerifyPasswordReq req =
+                UserVerifyPasswordReq.builder().password(TEST_USER_PASSWORD).build();
+        UserVerifyPasswordRes res = UserVerifyPasswordRes.builder().isMatched(true).build();
+        when(userService.verifyPassword(req)).thenReturn(res);
+
+        // when - then
+        mvc.perform(
+                        post("/api/v1/users/password/verify")
+                                .content(objectMapper.writeValueAsString(req))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .principal(mockPrincipal))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("프로필 수정 api 테스트")
+    void updateProfileTest() throws Exception {
+        // given
+        mockUserSetup();
+
+        String imageUrl = "images/image1.jpg";
+        Resource fileResource = new ClassPathResource(imageUrl);
+        MockMultipartFile file =
+                new MockMultipartFile(
+                        "image", fileResource.getFilename(), IMAGE_JPEG_VALUE, fileResource.getInputStream());
+
+        UserUpdateProfileReq request =
+                UserUpdateProfileReq.builder()
+                        .userId(TEST_USER_ID)
+                        .username(TEST_ANOTHER_USER_NAME)
+                        .password(TEST_USER_PASSWORD)
+                        .introduce(TEST_USER_INTRODUCE)
+                        .build();
+
+        MockMultipartFile req =
+                new MockMultipartFile(
+                        "data",
+                        null,
+                        "application/json",
+                        objectMapper.writeValueAsString(request).getBytes(StandardCharsets.UTF_8));
+
+        UserUpdateProfileRes res = new UserUpdateProfileRes();
+        when(userService.updateProfile(request, file)).thenReturn(res);
+
+        // when - then
+        mvc.perform(
+                        MockMvcRequestBuilders.multipart(HttpMethod.PATCH, "/api/v1/users")
+                                .file(file)
+                                .file(req)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                                .principal(mockPrincipal))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("프로필 조회 api 테스트")
+    void getProfileTest() throws Exception {
+        // given
+        UserGetProfileRes res =
+                UserGetProfileRes.builder()
+                        .userId(TEST_USER_ID)
+                        .username(TEST_USER_NAME)
+                        .email(TEST_USER_EMAIL)
+                        .introduce(TEST_USER_INTRODUCE)
+                        .profileImageUrl(TEST_USER_PROFILE_URL)
+                        .build();
+        when(userService.getProfile(TEST_USER_ID)).thenReturn(res);
+
+        // when - then
+        mvc.perform(get("/api/v1/users/{userId}", TEST_USER_ID))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/vt/valuetogether/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/user/controller/UserControllerTest.java
@@ -43,6 +43,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -74,7 +75,7 @@ class UserControllerTest extends BaseMvcTest implements UserTest {
     }
 
     private void mockUserSetup() {
-        UserDetailsImpl testUserDetails = new UserDetailsImpl(TEST_USER);
+        UserDetails testUserDetails = new UserDetailsImpl(TEST_USER);
         mockPrincipal =
                 new UsernamePasswordAuthenticationToken(
                         testUserDetails, "", testUserDetails.getAuthorities());
@@ -90,7 +91,7 @@ class UserControllerTest extends BaseMvcTest implements UserTest {
 
         // when - then
         mvc.perform(
-                        post("/api/v1/users/email")
+                        post("/api/v1/users/signup/email")
                                 .content(objectMapper.writeValueAsString(req))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON))
@@ -113,7 +114,7 @@ class UserControllerTest extends BaseMvcTest implements UserTest {
         info.add("authCode", code);
 
         // when - then
-        mvc.perform(get("/api/v1/users/confirm-email").params(info))
+        mvc.perform(get("/api/v1/users/signup/email/check").params(info))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -195,7 +196,6 @@ class UserControllerTest extends BaseMvcTest implements UserTest {
 
         UserUpdateProfileReq request =
                 UserUpdateProfileReq.builder()
-                        .userId(TEST_USER_ID)
                         .username(TEST_ANOTHER_USER_NAME)
                         .password(TEST_USER_PASSWORD)
                         .introduce(TEST_USER_INTRODUCE)

--- a/src/test/java/com/vt/valuetogether/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.vt.valuetogether.domain.user.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.vt.valuetogether.domain.user.entity.User;
+import com.vt.valuetogether.test.UserTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryTest implements UserTest {
+
+    @Autowired private UserRepository userRepository;
+
+    @Test
+    @DisplayName("save 테스트")
+    void saveTest() {
+        // given
+
+        // when
+        User saveUser = userRepository.save(TEST_USER);
+
+        // then
+        assertEquals(saveUser.getUserId(), TEST_USER_ID);
+        assertEquals(saveUser.getUsername(), TEST_USER_NAME);
+        assertEquals(saveUser.getEmail(), TEST_USER_EMAIL);
+        assertEquals(saveUser.getProfileImageUrl(), TEST_USER_PROFILE_URL);
+    }
+
+    @Test
+    @DisplayName("username으로 User 조회")
+    void findByUsernameTest() {
+        // given
+        User saveUser = userRepository.save(TEST_USER);
+
+        // when
+        User user = userRepository.findByUsername(saveUser.getUsername());
+
+        // then
+        assertEquals(user.getUserId(), saveUser.getUserId());
+        assertEquals(user.getUsername(), saveUser.getUsername());
+        assertEquals(user.getEmail(), saveUser.getEmail());
+        assertEquals(user.getProfileImageUrl(), saveUser.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("userId로 User 조회")
+    void findByUserIdTest() {
+        // given
+        User saveUser = userRepository.save(TEST_USER);
+
+        // when
+        User user = userRepository.findByUserId(saveUser.getUserId());
+
+        // then
+        assertEquals(user.getUserId(), saveUser.getUserId());
+        assertEquals(user.getUsername(), saveUser.getUsername());
+        assertEquals(user.getEmail(), saveUser.getEmail());
+        assertEquals(user.getProfileImageUrl(), saveUser.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("username 중복 확인")
+    void existsByUsernameTest() {
+        // given
+        User saveUser = userRepository.save(TEST_USER);
+
+        // when
+        boolean isDuplicated = userRepository.existsByUsername(saveUser.getUsername());
+
+        // then
+        assertTrue(isDuplicated);
+    }
+}

--- a/src/test/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
 
 import com.vt.valuetogether.domain.user.dto.request.UserCheckDuplicateUsernameReq;
 import com.vt.valuetogether.domain.user.dto.request.UserSignupReq;
@@ -171,7 +172,7 @@ class UserServiceImplTest implements UserTest {
                         .email(TEST_USER_EMAIL)
                         .build();
 
-        given(userRepository.findByUsername(TEST_USER_NAME)).willReturn(TEST_USER);
+        given(userRepository.existsByUsername(req.getUsername())).willReturn(true);
 
         // when
         GlobalException exception =
@@ -199,7 +200,7 @@ class UserServiceImplTest implements UserTest {
         EmailAuth emailAuth =
                 EmailAuth.builder().email(TEST_USER_EMAIL).code("aaa").isChecked(true).build();
 
-        given(userRepository.findByUsername(TEST_USER_NAME)).willReturn(null);
+        given(userRepository.existsByUsername(TEST_USER_NAME)).willReturn(false);
         given(userRepository.save(any(User.class))).willReturn(TEST_USER);
         given(mailUtil.getEmailAuth(TEST_USER_EMAIL)).willReturn(emailAuth);
 
@@ -208,7 +209,7 @@ class UserServiceImplTest implements UserTest {
 
         // then
         verify(passwordEncoder).encode(TEST_USER_PASSWORD);
-        verify(userRepository).findByUsername(TEST_USER_NAME);
+        verify(userRepository).existsByUsername(TEST_USER_NAME);
         verify(userRepository).save(any(User.class));
 
         verify(userRepository).save(argumentCaptor.capture());
@@ -222,7 +223,7 @@ class UserServiceImplTest implements UserTest {
         UserCheckDuplicateUsernameReq req =
                 UserCheckDuplicateUsernameReq.builder().username(TEST_ANOTHER_USER_NAME).build();
 
-        given(userRepository.findByUsername(req.getUsername())).willReturn(TEST_ANOTHER_USER);
+        given(userRepository.existsByUsername(req.getUsername())).willReturn(true);
 
         // when
         UserCheckDuplicateUsernameRes res = userService.checkDuplicateUsername(req);
@@ -266,7 +267,7 @@ class UserServiceImplTest implements UserTest {
 
         MultipartFile multipartFile =
                 new MockMultipartFile(
-                        "image", fileResource.getFilename(), "image/jpeg", fileResource.getInputStream());
+                        "image", fileResource.getFilename(), IMAGE_JPEG_VALUE, fileResource.getInputStream());
 
         User UPDATED_USER =
                 User.builder()

--- a/src/test/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImplTest.java
@@ -13,6 +13,7 @@ import com.vt.valuetogether.domain.user.dto.request.UserUpdateProfileReq;
 import com.vt.valuetogether.domain.user.dto.request.UserVerifyEmailReq;
 import com.vt.valuetogether.domain.user.dto.request.UserVerifyPasswordReq;
 import com.vt.valuetogether.domain.user.dto.response.UserCheckDuplicateUsernameRes;
+import com.vt.valuetogether.domain.user.dto.response.UserGetProfileRes;
 import com.vt.valuetogether.domain.user.dto.response.UserVerifyPasswordRes;
 import com.vt.valuetogether.domain.user.entity.EmailAuth;
 import com.vt.valuetogether.domain.user.entity.Role;
@@ -293,5 +294,20 @@ class UserServiceImplTest implements UserTest {
         assertEquals(TEST_ANOTHER_USER_PASSWORD, argumentCaptor.getValue().getPassword());
         assertEquals(TEST_ANOTHER_USER_INTRODUCE, argumentCaptor.getValue().getIntroduce());
         assertEquals(TEST_ANOTHER_USER_PROFILE_URL, argumentCaptor.getValue().getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("프로필 조회")
+    void getProfileTest() {
+        // given
+        given(userRepository.findByUserId(TEST_USER_ID)).willReturn(TEST_USER);
+
+        // when
+        UserGetProfileRes res = userService.getProfile(TEST_USER_ID);
+
+        // then
+        assertEquals(TEST_USER_NAME, res.getUsername());
+        assertEquals(TEST_USER_EMAIL, res.getEmail());
+        assertEquals(TEST_USER_INTRODUCE, res.getIntroduce());
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/user/service/impl/UserServiceImplTest.java
@@ -237,9 +237,12 @@ class UserServiceImplTest implements UserTest {
     void verifyPasswordTest() {
         // given
         UserVerifyPasswordReq req =
-                UserVerifyPasswordReq.builder().userId(TEST_USER_ID).password(TEST_USER_PASSWORD).build();
+                UserVerifyPasswordReq.builder()
+                        .username(TEST_USER_NAME)
+                        .password(TEST_USER_PASSWORD)
+                        .build();
 
-        given(userRepository.findByUserId(req.getUserId())).willReturn(TEST_USER);
+        given(userRepository.findByUsername(req.getUsername())).willReturn(TEST_USER);
         given(passwordEncoder.matches(req.getPassword(), TEST_USER_PASSWORD))
                 .willReturn(req.getPassword().equals(TEST_USER_PASSWORD));
 
@@ -256,7 +259,7 @@ class UserServiceImplTest implements UserTest {
         // given
         UserUpdateProfileReq req =
                 UserUpdateProfileReq.builder()
-                        .userId(TEST_USER_ID)
+                        .preUsername(TEST_USER_NAME)
                         .username(TEST_ANOTHER_USER_NAME)
                         .password(TEST_ANOTHER_USER_PASSWORD)
                         .introduce(TEST_ANOTHER_USER_INTRODUCE)
@@ -280,7 +283,7 @@ class UserServiceImplTest implements UserTest {
                         .role(Role.USER)
                         .build();
 
-        given(userRepository.findByUserId(req.getUserId())).willReturn(TEST_USER);
+        given(userRepository.findByUsername(req.getPreUsername())).willReturn(TEST_USER);
         given(passwordEncoder.encode(req.getPassword())).willReturn(req.getPassword());
         given(s3Util.uploadFile(multipartFile, FilePath.PROFILE))
                 .willReturn(TEST_ANOTHER_USER_PROFILE_URL);

--- a/src/test/java/com/vt/valuetogether/global/MockSpringSecurityFilter.java
+++ b/src/test/java/com/vt/valuetogether/global/MockSpringSecurityFilter.java
@@ -1,0 +1,30 @@
+package com.vt.valuetogether.global;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class MockSpringSecurityFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+            throws IOException, ServletException, ServletException {
+        SecurityContextHolder.getContext()
+                .setAuthentication((Authentication) ((HttpServletRequest) req).getUserPrincipal());
+        chain.doFilter(req, res);
+    }
+
+    @Override
+    public void destroy() {
+        SecurityContextHolder.clearContext();
+    }
+}


### PR DESCRIPTION
## 개요
프로필 조회 기능 및 테스트 코드를 추가했습니다.

## 작업사항
- 프로필 조회 API
- repository, controller 테스트 코드 추가

## 관련 이슈
- 회원가입 관련 api만 허용하도록 WebSecurityConfig 파일을 수정했습니다.
- 프로필 수정 시 multipartFile.isEmpty()에서 에러가 나서 multipartFile==null 로직을 추가했습니다.
- close #75 
