### PR TITLE
card sequence 재정렬 스케줄링 추가

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
@@ -1,6 +1,7 @@
 package com.vt.valuetogether.domain.card.repository;
 
 import com.vt.valuetogether.domain.card.entity.Card;
+import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 
@@ -14,4 +15,8 @@ public interface CardRepository {
     Card findByCardId(Long cardId);
 
     void delete(Card card);
+
+    List<Card> findByOrderByCategoryIdAscSequenceDesc();
+
+    List<Card> saveAll(Iterable<Card> cards);
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
@@ -16,7 +16,7 @@ public interface CardRepository {
 
     void delete(Card card);
 
-    List<Card> findByOrderByCategoryIdAscSequenceDesc();
+    List<Card> findByOrderByCategoryIdAscSequenceAsc();
 
     List<Card> saveAll(Iterable<Card> cards);
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/service/CardSchedulingService.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/CardSchedulingService.java
@@ -1,0 +1,5 @@
+package com.vt.valuetogether.domain.card.service;
+
+public interface CardSchedulingService {
+    void resetSequence();
+}

--- a/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardSchedulingServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardSchedulingServiceImpl.java
@@ -19,7 +19,7 @@ public class CardSchedulingServiceImpl implements CardSchedulingService {
 
     @Scheduled(cron = "0 0 0 * * ?")
     public void resetSequence() {
-        List<Card> cards = cardRepository.findByOrderByCategoryIdAscSequenceDesc();
+        List<Card> cards = cardRepository.findByOrderByCategoryIdAscSequenceAsc();
         Long prevCategoryId = cards.get(0).getCategoryId();
         double sequence = 0.0;
         List<Card> newCards = new ArrayList<>();

--- a/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardSchedulingServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardSchedulingServiceImpl.java
@@ -1,0 +1,49 @@
+package com.vt.valuetogether.domain.card.service.impl;
+
+import com.vt.valuetogether.domain.card.entity.Card;
+import com.vt.valuetogether.domain.card.repository.CardRepository;
+import com.vt.valuetogether.domain.card.service.CardSchedulingService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@EnableScheduling
+@RequiredArgsConstructor
+public class CardSchedulingServiceImpl implements CardSchedulingService {
+    private final CardRepository cardRepository;
+    private final double ADD_SEQUENCE = 1.0;
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void resetSequence() {
+        List<Card> cards = cardRepository.findByOrderByCategoryIdAscSequenceDesc();
+        Long prevCategoryId = cards.get(0).getCategoryId();
+        double sequence = 0.0;
+        List<Card> newCards = new ArrayList<>();
+        for (Card card : cards) {
+            sequence = getNewSequence(sequence, prevCategoryId, card.getCategoryId());
+            newCards.add(
+                    Card.builder()
+                            .cardId(card.getCardId())
+                            .name(card.getName())
+                            .description(card.getDescription())
+                            .fileUrl(card.getFileUrl())
+                            .sequence(sequence)
+                            .deadline(card.getDeadline())
+                            .categoryId(card.getCategoryId())
+                            .build());
+            prevCategoryId = card.getCategoryId();
+        }
+        cardRepository.saveAll(newCards);
+    }
+
+    private double getNewSequence(double sequence, Long prevCategoryId, Long nowCategoryId) {
+        if (!prevCategoryId.equals(nowCategoryId)) {
+            return ADD_SEQUENCE;
+        }
+        return sequence + ADD_SEQUENCE;
+    }
+}

--- a/src/main/java/com/vt/valuetogether/domain/checklist/entity/Checklist.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/entity/Checklist.java
@@ -33,7 +33,7 @@ public class Checklist extends BaseEntity {
     @JoinColumn(name = "cardId")
     private Card card;
 
-    @OneToMany(mappedBy = "checklist", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "checklist", cascade = CascadeType.ALL)
     private List<Task> tasks;
 
     @Builder

--- a/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.test.CardTest;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,5 +77,28 @@ class CardRepositoryTest implements CardTest {
 
         // then
         assertThat(card).isNull();
+    }
+
+    @Test
+    @DisplayName("categoryId별 card list 조회 테스트")
+    void categoryId_card_list_조회() {
+        // given
+        Card saveCard = cardRepository.save(TEST_CARD);
+        Card saveAnotherCard = cardRepository.save(TEST_ANOTHER_CARD);
+
+        // when
+        List<Card> cards = cardRepository.findByOrderByCategoryIdAscSequenceAsc();
+
+        // then
+        assertThat(cards.get(0).getName()).isEqualTo(saveCard.getName());
+        assertThat(cards.get(0).getDescription()).isEqualTo(saveCard.getDescription());
+        assertThat(cards.get(0).getFileUrl()).isEqualTo(saveCard.getFileUrl());
+        assertThat(cards.get(0).getSequence()).isEqualTo(saveCard.getSequence());
+        assertThat(cards.get(0).getDeadline()).isEqualTo(saveCard.getDeadline());
+        assertThat(cards.get(1).getName()).isEqualTo(saveAnotherCard.getName());
+        assertThat(cards.get(1).getDescription()).isEqualTo(saveAnotherCard.getDescription());
+        assertThat(cards.get(1).getFileUrl()).isEqualTo(saveAnotherCard.getFileUrl());
+        assertThat(cards.get(1).getSequence()).isEqualTo(saveAnotherCard.getSequence());
+        assertThat(cards.get(1).getDeadline()).isEqualTo(saveAnotherCard.getDeadline());
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
@@ -101,4 +101,26 @@ class CardRepositoryTest implements CardTest {
         assertThat(cards.get(1).getSequence()).isEqualTo(saveAnotherCard.getSequence());
         assertThat(cards.get(1).getDeadline()).isEqualTo(saveAnotherCard.getDeadline());
     }
+
+    @Test
+    @DisplayName("cards 저장 테스트")
+    void cards_저장() {
+        // given
+        List<Card> cards = List.of(TEST_CARD, TEST_ANOTHER_CARD);
+
+        // when
+        List<Card> saveCards = cardRepository.saveAll(cards);
+
+        // then
+        assertThat(saveCards.get(0).getName()).isEqualTo(TEST_NAME);
+        assertThat(saveCards.get(0).getDescription()).isEqualTo(TEST_DESCRIPTION);
+        assertThat(saveCards.get(0).getFileUrl()).isEqualTo(TEST_FILE_URL);
+        assertThat(saveCards.get(0).getSequence()).isEqualTo(TEST_SEQUENCE);
+        assertThat(saveCards.get(0).getDeadline()).isEqualTo(TEST_DEADLINE);
+        assertThat(saveCards.get(1).getName()).isEqualTo(TEST_ANOTHER_NAME);
+        assertThat(saveCards.get(1).getDescription()).isEqualTo(TEST_ANOTHER_DESCRIPTION);
+        assertThat(saveCards.get(1).getFileUrl()).isEqualTo(TEST_ANOTHER_FILE_URL);
+        assertThat(saveCards.get(1).getSequence()).isEqualTo(TEST_ANOTHER_SEQUENCE);
+        assertThat(saveCards.get(1).getDeadline()).isEqualTo(TEST_ANOTHER_DEADLINE);
+    }
 }

--- a/src/test/java/com/vt/valuetogether/test/CardTest.java
+++ b/src/test/java/com/vt/valuetogether/test/CardTest.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 public interface CardTest {
 
     Long TEST_CARD_ID = 1L;
-
     String TEST_NAME = "name";
     String TEST_DESCRIPTION = "description";
     String TEST_FILE_URL = "url";
@@ -18,6 +17,13 @@ public interface CardTest {
     String TEST_UPDATED_DESCRIPTION = "updatedDescription";
     String TEST_UPDATED_FILE_URL = "updatedUrl";
     LocalDateTime TEST_UPDATED_DEADLINE = LocalDateTime.now().plusDays(1L);
+
+    Long TEST_ANOTHER_CARD_ID = 2L;
+    String TEST_ANOTHER_NAME = "anotherName";
+    String TEST_ANOTHER_DESCRIPTION = "anotherDescription";
+    String TEST_ANOTHER_FILE_URL = "anotherUrl";
+    Double TEST_ANOTHER_SEQUENCE = 2.0;
+    LocalDateTime TEST_ANOTHER_DEADLINE = LocalDateTime.now().plusDays(1L);
 
     Card TEST_CARD =
             Card.builder()
@@ -38,6 +44,17 @@ public interface CardTest {
                     .fileUrl(TEST_UPDATED_FILE_URL)
                     .sequence(TEST_SEQUENCE)
                     .deadline(TEST_UPDATED_DEADLINE)
+                    .categoryId(TEST_CATEGORY_ID)
+                    .build();
+
+    Card TEST_ANOTHER_CARD =
+            Card.builder()
+                    .cardId(TEST_ANOTHER_CARD_ID)
+                    .name(TEST_ANOTHER_NAME)
+                    .description(TEST_ANOTHER_DESCRIPTION)
+                    .fileUrl(TEST_ANOTHER_FILE_URL)
+                    .sequence(TEST_ANOTHER_SEQUENCE)
+                    .deadline(TEST_ANOTHER_DEADLINE)
                     .categoryId(TEST_CATEGORY_ID)
                     .build();
 }


### PR DESCRIPTION
## 개요
card sequence 재정렬 스케줄링을 추가합니다.

## 작업사항
- card sequence 재정렬 스케줄링 추가
   - 매일 0시 0분 0초에 실행
- 테스트 코드 추가

## 관련 이슈
- close #85 
