### PR TITLE
카테고리 수정 API 구현

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/controller/CategoryController.java
@@ -1,10 +1,15 @@
 package com.vt.valuetogether.domain.category.controller;
 
+import com.vt.valuetogether.domain.category.dto.request.CategoryEditReq;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
+import com.vt.valuetogether.domain.category.dto.response.CategoryEditRes;
 import com.vt.valuetogether.domain.category.dto.response.CategorySaveRes;
 import com.vt.valuetogether.domain.category.service.CategoryService;
 import com.vt.valuetogether.global.response.RestResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,11 +19,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/categories")
 @RequiredArgsConstructor
 public class CategoryController {
+
     private final CategoryService categoryService;
 
     @PostMapping
-    public RestResponse<CategorySaveRes> saveCategory(@RequestBody CategorySaveReq categorySaveReq) {
-        // TODO add userDetails
+    public RestResponse<CategorySaveRes> saveCategory(
+            @RequestBody CategorySaveReq categorySaveReq,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        categorySaveReq.setUsername(userDetails.getUsername());
         return RestResponse.success(categoryService.saveCategory(categorySaveReq));
+    }
+
+    @PatchMapping
+    public RestResponse<CategoryEditRes> editCategory(
+            @RequestBody CategoryEditReq req, @AuthenticationPrincipal UserDetails userDetails) {
+        req.setUsername(userDetails.getUsername());
+        return RestResponse.success(categoryService.editCategory(req));
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryEditReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryEditReq.java
@@ -9,14 +9,14 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CategorySaveReq {
-    private Long teamId;
+public class CategoryEditReq {
+    private Long categoryId;
     private String name;
     private String username;
 
     @Builder
-    private CategorySaveReq(Long teamId, String name, String username) {
-        this.teamId = teamId;
+    private CategoryEditReq(Long categoryId, String name, String username) {
+        this.categoryId = categoryId;
         this.name = name;
         this.username = username;
     }

--- a/src/main/java/com/vt/valuetogether/domain/category/dto/response/CategoryEditRes.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/response/CategoryEditRes.java
@@ -1,0 +1,6 @@
+package com.vt.valuetogether.domain.category.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class CategoryEditRes {}

--- a/src/main/java/com/vt/valuetogether/domain/category/service/CategoryService.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/CategoryService.java
@@ -1,8 +1,12 @@
 package com.vt.valuetogether.domain.category.service;
 
+import com.vt.valuetogether.domain.category.dto.request.CategoryEditReq;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
+import com.vt.valuetogether.domain.category.dto.response.CategoryEditRes;
 import com.vt.valuetogether.domain.category.dto.response.CategorySaveRes;
 
 public interface CategoryService {
     CategorySaveRes saveCategory(CategorySaveReq categorySaveReq);
+
+    CategoryEditRes editCategory(CategoryEditReq req);
 }

--- a/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImpl.java
@@ -1,6 +1,5 @@
 package com.vt.valuetogether.domain.category.service.impl;
 
-import static com.vt.valuetogether.global.meta.ResultCode.FORBIDDEN_TEAM_ROLE;
 import static java.lang.Boolean.FALSE;
 
 import com.vt.valuetogether.domain.category.dto.request.CategoryEditReq;
@@ -15,7 +14,6 @@ import com.vt.valuetogether.domain.team.entity.Team;
 import com.vt.valuetogether.domain.team.repository.TeamRepository;
 import com.vt.valuetogether.domain.user.entity.User;
 import com.vt.valuetogether.domain.user.repository.UserRepository;
-import com.vt.valuetogether.global.exception.GlobalException;
 import com.vt.valuetogether.global.validator.CategoryValidator;
 import com.vt.valuetogether.global.validator.TeamRoleValidator;
 import com.vt.valuetogether.global.validator.TeamValidator;
@@ -63,24 +61,18 @@ public class CategoryServiceImpl implements CategoryService {
         Team team = category.getTeam();
         TeamValidator.validate(team);
 
-        team.getTeamRoleList().stream()
-                .filter(
-                        teamRole ->
-                                teamRole.getUser().getUsername().equals(req.getUsername()) && !teamRole.isDeleted())
-                .findAny()
-                .ifPresentOrElse(
-                        teamRole ->
-                                categoryRepository.save(
-                                        Category.builder()
-                                                .categoryId(category.getCategoryId())
-                                                .name(req.getName())
-                                                .sequence(category.getSequence())
-                                                .team(team)
-                                                .isDeleted(false)
-                                                .build()),
-                        () -> {
-                            throw new GlobalException(FORBIDDEN_TEAM_ROLE);
-                        });
+        TeamRoleValidator.validate(team.getTeamRoleList());
+        TeamRoleValidator.checkIsTeamMember(team.getTeamRoleList(), user);
+
+        categoryRepository.save(
+                Category.builder()
+                        .categoryId(category.getCategoryId())
+                        .name(req.getName())
+                        .sequence(category.getSequence())
+                        .team(team)
+                        .isDeleted(false)
+                        .build());
+
         return new CategoryEditRes();
     }
 

--- a/src/main/java/com/vt/valuetogether/global/meta/ResultCode.java
+++ b/src/main/java/com/vt/valuetogether/global/meta/ResultCode.java
@@ -42,6 +42,7 @@ public enum ResultCode {
     NOT_FOUND_TEAM_MEMBER(HttpStatus.NOT_FOUND, 3006, "팀의 멤버가 아닙니다."),
 
     // 카테고리 4000번대
+    NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, 4000, "존재하지 않는 카테고리 입니다."),
 
     // 카드 5000번대
     NOT_FOUND_CARD(HttpStatus.NOT_FOUND, 5000, "카드 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/vt/valuetogether/global/validator/CategoryValidator.java
+++ b/src/main/java/com/vt/valuetogether/global/validator/CategoryValidator.java
@@ -1,0 +1,23 @@
+package com.vt.valuetogether.global.validator;
+
+import static com.vt.valuetogether.global.meta.ResultCode.NOT_FOUND_CATEGORY;
+
+import com.vt.valuetogether.domain.category.entity.Category;
+import com.vt.valuetogether.global.exception.GlobalException;
+
+public class CategoryValidator {
+    public static void validate(Category category) {
+        // 카테고리가 존재하지 않거나 삭제된 경우 NOT_FOUND_CATEGORY Exception 발생
+        if (checkIsNull(category) || checkIsDeleted(category)) {
+            throw new GlobalException(NOT_FOUND_CATEGORY);
+        }
+    }
+
+    private static boolean checkIsNull(Category category) {
+        return category == null;
+    }
+
+    private static boolean checkIsDeleted(Category category) {
+        return category.getIsDeleted();
+    }
+}

--- a/src/main/java/com/vt/valuetogether/global/validator/TeamRoleValidator.java
+++ b/src/main/java/com/vt/valuetogether/global/validator/TeamRoleValidator.java
@@ -7,6 +7,7 @@ import com.vt.valuetogether.domain.team.entity.TeamRole;
 import com.vt.valuetogether.domain.user.entity.User;
 import com.vt.valuetogether.global.exception.GlobalException;
 import java.util.List;
+import org.springframework.util.CollectionUtils;
 
 public class TeamRoleValidator {
 
@@ -23,7 +24,7 @@ public class TeamRoleValidator {
     }
 
     private static boolean checkIsNull(List<TeamRole> teamRoleList) {
-        return teamRoleList.isEmpty();
+        return CollectionUtils.isEmpty(teamRoleList);
     }
 
     private static boolean teamRoleListContainsUser(List<TeamRole> teamRoleList, User user) {


### PR DESCRIPTION
## 개요
카테고리 수정 API를 구현합니다.

## 작업사항
- 카테고리 수정 API 추가
- Validator 추가
- TeamRoleValidator checkIsNull 부분 수정
- saveCategory에 userDetails 추가

## 관련 이슈
- close #97 
