### PR TITLE
카테고리 삭제 API 구현

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/controller/CategoryController.java
@@ -1,7 +1,9 @@
 package com.vt.valuetogether.domain.category.controller;
 
+import com.vt.valuetogether.domain.category.dto.request.CategoryDeleteReq;
 import com.vt.valuetogether.domain.category.dto.request.CategoryEditReq;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
+import com.vt.valuetogether.domain.category.dto.response.CategoryDeleteRes;
 import com.vt.valuetogether.domain.category.dto.response.CategoryEditRes;
 import com.vt.valuetogether.domain.category.dto.response.CategorySaveRes;
 import com.vt.valuetogether.domain.category.service.CategoryService;
@@ -9,6 +11,7 @@ import com.vt.valuetogether.global.response.RestResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,5 +38,12 @@ public class CategoryController {
             @RequestBody CategoryEditReq req, @AuthenticationPrincipal UserDetails userDetails) {
         req.setUsername(userDetails.getUsername());
         return RestResponse.success(categoryService.editCategory(req));
+    }
+
+    @DeleteMapping
+    public RestResponse<CategoryDeleteRes> deleteCategory(
+            @RequestBody CategoryDeleteReq req, @AuthenticationPrincipal UserDetails userDetails) {
+        req.setUsername(userDetails.getUsername());
+        return RestResponse.success(categoryService.deleteCategory(req));
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryDeleteReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryDeleteReq.java
@@ -1,0 +1,21 @@
+package com.vt.valuetogether.domain.category.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategoryDeleteReq {
+    private Long categoryId;
+    private String username;
+
+    @Builder
+    private CategoryDeleteReq(Long categoryId, String username) {
+        this.categoryId = categoryId;
+        this.username = username;
+    }
+}

--- a/src/main/java/com/vt/valuetogether/domain/category/dto/response/CategoryDeleteRes.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/response/CategoryDeleteRes.java
@@ -1,0 +1,6 @@
+package com.vt.valuetogether.domain.category.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class CategoryDeleteRes {}

--- a/src/main/java/com/vt/valuetogether/domain/category/service/CategoryService.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/CategoryService.java
@@ -1,7 +1,9 @@
 package com.vt.valuetogether.domain.category.service;
 
+import com.vt.valuetogether.domain.category.dto.request.CategoryDeleteReq;
 import com.vt.valuetogether.domain.category.dto.request.CategoryEditReq;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
+import com.vt.valuetogether.domain.category.dto.response.CategoryDeleteRes;
 import com.vt.valuetogether.domain.category.dto.response.CategoryEditRes;
 import com.vt.valuetogether.domain.category.dto.response.CategorySaveRes;
 
@@ -9,4 +11,6 @@ public interface CategoryService {
     CategorySaveRes saveCategory(CategorySaveReq categorySaveReq);
 
     CategoryEditRes editCategory(CategoryEditReq req);
+
+    CategoryDeleteRes deleteCategory(CategoryDeleteReq req);
 }

--- a/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImpl.java
@@ -2,8 +2,10 @@ package com.vt.valuetogether.domain.category.service.impl;
 
 import static java.lang.Boolean.FALSE;
 
+import com.vt.valuetogether.domain.category.dto.request.CategoryDeleteReq;
 import com.vt.valuetogether.domain.category.dto.request.CategoryEditReq;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
+import com.vt.valuetogether.domain.category.dto.response.CategoryDeleteRes;
 import com.vt.valuetogether.domain.category.dto.response.CategoryEditRes;
 import com.vt.valuetogether.domain.category.dto.response.CategorySaveRes;
 import com.vt.valuetogether.domain.category.entity.Category;
@@ -74,6 +76,33 @@ public class CategoryServiceImpl implements CategoryService {
                         .build());
 
         return new CategoryEditRes();
+    }
+
+    @Override
+    @Transactional
+    public CategoryDeleteRes deleteCategory(CategoryDeleteReq req) {
+        User user = userRepository.findByUsername(req.getUsername());
+        UserValidator.validate(user);
+
+        Category category = categoryRepository.findByCategoryId(req.getCategoryId());
+        CategoryValidator.validate(category);
+
+        Team team = category.getTeam();
+        TeamValidator.validate(team);
+
+        TeamRoleValidator.validate(team.getTeamRoleList());
+        TeamRoleValidator.checkIsTeamMember(team.getTeamRoleList(), user);
+
+        categoryRepository.save(
+                Category.builder()
+                        .categoryId(category.getCategoryId())
+                        .name(category.getName())
+                        .sequence(0.0)
+                        .team(team)
+                        .isDeleted(true)
+                        .build());
+
+        return new CategoryDeleteRes();
     }
 
     private Double getMaxSequence(Long teamId) {


### PR DESCRIPTION
## 개요
카테고리 삭제 API를 구현합니다.

## 작업사항
- `categoryId`를 전달해 카테고리를 삭제할 수 있다.
- team member만 해당 API를 수행할 수 있다.

## 관련 이슈
- close #99 
