### PR TITLE
team validator 추가

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/card/controller/CardController.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/controller/CardController.java
@@ -12,6 +12,8 @@ import com.vt.valuetogether.domain.card.dto.response.CardUpdateRes;
 import com.vt.valuetogether.domain.card.service.CardService;
 import com.vt.valuetogether.global.response.RestResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,30 +34,39 @@ public class CardController {
     @PostMapping
     public RestResponse<CardSaveRes> saveCard(
             @RequestPart CardSaveReq cardSaveReq,
-            @RequestPart(required = false) MultipartFile multipartFile) {
+            @RequestPart(required = false) MultipartFile multipartFile,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        cardSaveReq.setUsername(userDetails.getUsername());
         return RestResponse.success(cardService.saveCard(cardSaveReq, multipartFile));
     }
 
     @PatchMapping
     public RestResponse<CardUpdateRes> updateCard(
             @RequestPart CardUpdateReq cardUpdateReq,
-            @RequestPart(required = false) MultipartFile multipartFile) {
+            @RequestPart(required = false) MultipartFile multipartFile,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        cardUpdateReq.setUsername(userDetails.getUsername());
         return RestResponse.success(cardService.updateCard(cardUpdateReq, multipartFile));
     }
 
     @DeleteMapping
-    public RestResponse<CardDeleteRes> deleteCard(@RequestBody CardDeleteReq cardDeleteReq) {
+    public RestResponse<CardDeleteRes> deleteCard(
+            @RequestBody CardDeleteReq cardDeleteReq, @AuthenticationPrincipal UserDetails userDetails) {
+        cardDeleteReq.setUsername(userDetails.getUsername());
         return RestResponse.success(cardService.deleteCard(cardDeleteReq));
     }
 
     @GetMapping("/{cardId}")
-    public RestResponse<CardGetRes> getCard(@PathVariable Long cardId) {
-        return RestResponse.success(cardService.getCard(cardId));
+    public RestResponse<CardGetRes> getCard(
+            @PathVariable Long cardId, @AuthenticationPrincipal UserDetails userDetails) {
+        return RestResponse.success(cardService.getCard(cardId, userDetails.getUsername()));
     }
 
     @PatchMapping("/order")
     public RestResponse<CardChangeSequenceRes> changeSequence(
-            @RequestBody CardChangeSequenceReq cardChangeSequenceReq) {
+            @RequestBody CardChangeSequenceReq cardChangeSequenceReq,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        cardChangeSequenceReq.setUsername(userDetails.getUsername());
         return RestResponse.success(cardService.changeSequence(cardChangeSequenceReq));
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardChangeSequenceReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardChangeSequenceReq.java
@@ -4,7 +4,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CardChangeSequenceReq {
@@ -13,6 +15,7 @@ public class CardChangeSequenceReq {
     private Long cardId;
     private Double preSequence;
     private Double postSequence;
+    private String username;
 
     @Builder
     private CardChangeSequenceReq(

--- a/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardDeleteReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardDeleteReq.java
@@ -4,11 +4,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CardDeleteReq {
     private Long cardId;
+    private String username;
 
     @Builder
     private CardDeleteReq(Long cardId) {

--- a/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardSaveReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardSaveReq.java
@@ -5,7 +5,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CardSaveReq {
@@ -13,6 +15,7 @@ public class CardSaveReq {
     private String name;
     private String description;
     private LocalDateTime deadline;
+    private String username;
 
     @Builder
     private CardSaveReq(Long categoryId, String name, String description, LocalDateTime deadline) {

--- a/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardUpdateReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/dto/request/CardUpdateReq.java
@@ -5,7 +5,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CardUpdateReq {
@@ -13,6 +15,7 @@ public class CardUpdateReq {
     private String name;
     private String description;
     private LocalDateTime deadline;
+    private String username;
 
     @Builder
     private CardUpdateReq(Long cardId, String name, String description, LocalDateTime deadline) {

--- a/src/main/java/com/vt/valuetogether/domain/card/entity/Card.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/entity/Card.java
@@ -1,5 +1,6 @@
 package com.vt.valuetogether.domain.card.entity;
 
+import com.vt.valuetogether.domain.category.entity.Category;
 import com.vt.valuetogether.domain.checklist.entity.Checklist;
 import com.vt.valuetogether.domain.model.BaseEntity;
 import com.vt.valuetogether.domain.worker.entity.Worker;
@@ -8,6 +9,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -33,8 +36,9 @@ public class Card extends BaseEntity {
     private Double sequence;
     private LocalDateTime deadline;
 
-    // TODO FIX Category
-    private Long categoryId;
+    @ManyToOne
+    @JoinColumn(name = "categoryId")
+    private Category category;
 
     // TODO ADD Comments
     @OneToMany(mappedBy = "card", cascade = CascadeType.ALL)
@@ -51,13 +55,13 @@ public class Card extends BaseEntity {
             String fileUrl,
             Double sequence,
             LocalDateTime deadline,
-            Long categoryId) {
+            Category category) {
         this.cardId = cardId;
         this.name = name;
         this.description = description;
         this.fileUrl = fileUrl;
         this.sequence = sequence;
         this.deadline = deadline;
-        this.categoryId = categoryId;
+        this.category = category;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
@@ -18,7 +18,7 @@ public interface CardRepository {
 
     void delete(Card card);
 
-    List<Card> findByOrderByCategoryIdAscSequenceAsc();
+    List<Card> findByOrderByCategoryCategoryIdAscSequenceAsc();
 
     List<Card> saveAll(Iterable<Card> cards);
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/repository/CardRepository.java
@@ -9,7 +9,9 @@ import org.springframework.data.repository.RepositoryDefinition;
 public interface CardRepository {
     Card save(Card card);
 
-    @Query(value = "select ifnull(max(c.sequence), 0) from Card c where c.categoryId=:categoryId")
+    @Query(
+            value =
+                    "select ifnull(max(c.sequence), 0) + 1.0 from Card c where c.category.categoryId=:categoryId")
     Double getMaxSequence(Long categoryId);
 
     Card findByCardId(Long cardId);

--- a/src/main/java/com/vt/valuetogether/domain/card/service/CardService.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/CardService.java
@@ -18,7 +18,7 @@ public interface CardService {
 
     CardDeleteRes deleteCard(CardDeleteReq cardDeleteReq);
 
-    CardGetRes getCard(Long cardId);
+    CardGetRes getCard(Long cardId, String username);
 
     CardChangeSequenceRes changeSequence(CardChangeSequenceReq cardChangeSequenceReq);
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardSchedulingServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardSchedulingServiceImpl.java
@@ -19,12 +19,12 @@ public class CardSchedulingServiceImpl implements CardSchedulingService {
 
     @Scheduled(cron = "0 0 0 * * ?")
     public void resetSequence() {
-        List<Card> cards = cardRepository.findByOrderByCategoryIdAscSequenceAsc();
-        Long prevCategoryId = cards.get(0).getCategoryId();
+        List<Card> cards = cardRepository.findByOrderByCategoryCategoryIdAscSequenceAsc();
+        Long prevCategoryId = cards.get(0).getCategory().getCategoryId();
         double sequence = 0.0;
         List<Card> newCards = new ArrayList<>();
         for (Card card : cards) {
-            sequence = getNewSequence(sequence, prevCategoryId, card.getCategoryId());
+            sequence = getNewSequence(sequence, prevCategoryId, card.getCategory().getCategoryId());
             newCards.add(
                     Card.builder()
                             .cardId(card.getCardId())
@@ -33,9 +33,9 @@ public class CardSchedulingServiceImpl implements CardSchedulingService {
                             .fileUrl(card.getFileUrl())
                             .sequence(sequence)
                             .deadline(card.getDeadline())
-                            .categoryId(card.getCategoryId())
+                            .category(card.getCategory())
                             .build());
-            prevCategoryId = card.getCategoryId();
+            prevCategoryId = card.getCategory().getCategoryId();
         }
         cardRepository.saveAll(newCards);
     }

--- a/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImpl.java
@@ -15,7 +15,14 @@ import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.domain.card.repository.CardRepository;
 import com.vt.valuetogether.domain.card.service.CardService;
 import com.vt.valuetogether.domain.card.service.CardServiceMapper;
+import com.vt.valuetogether.domain.category.entity.Category;
+import com.vt.valuetogether.domain.category.repository.CategoryRepository;
+import com.vt.valuetogether.domain.user.entity.User;
+import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.global.validator.CardValidator;
+import com.vt.valuetogether.global.validator.CategoryValidator;
+import com.vt.valuetogether.global.validator.TeamRoleValidator;
+import com.vt.valuetogether.global.validator.UserValidator;
 import com.vt.valuetogether.infra.s3.S3Util;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,12 +33,18 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class CardServiceImpl implements CardService {
     private final CardRepository cardRepository;
+    private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
     private final S3Util s3Util;
 
     @Override
     @Transactional
     public CardSaveRes saveCard(CardSaveReq cardSaveReq, MultipartFile multipartFile) {
-        // TODO ADD Team check
+        User user = getUserByUsername(cardSaveReq.getUsername());
+        Category category = categoryRepository.findByCategoryId(cardSaveReq.getCategoryId());
+        CategoryValidator.validate(category);
+        TeamRoleValidator.checkIsTeamMember(category.getTeam().getTeamRoleList(), user);
+
         Double sequence = getMaxSequence(cardSaveReq.getCategoryId());
         String fileUrl = s3Util.uploadFile(multipartFile, CARD);
         return CardServiceMapper.INSTANCE.toCardSavaRes(
@@ -42,7 +55,7 @@ public class CardServiceImpl implements CardService {
                                 .fileUrl(fileUrl)
                                 .sequence(sequence)
                                 .deadline(cardSaveReq.getDeadline())
-                                .categoryId(cardSaveReq.getCategoryId())
+                                .category(category)
                                 .build()));
     }
 
@@ -53,9 +66,10 @@ public class CardServiceImpl implements CardService {
     @Override
     @Transactional
     public CardUpdateRes updateCard(CardUpdateReq cardUpdateReq, MultipartFile multipartFile) {
-        // TODO ADD Team check
-        Card prevCard = cardRepository.findByCardId(cardUpdateReq.getCardId());
-        CardValidator.validate(prevCard);
+        User user = getUserByUsername(cardUpdateReq.getUsername());
+        Card prevCard = getCardByCardId(cardUpdateReq.getCardId());
+        TeamRoleValidator.checkIsTeamMember(prevCard.getCategory().getTeam().getTeamRoleList(), user);
+
         deleteFile(prevCard.getFileUrl());
         String fileUrl = null;
         if (multipartFile != null && !multipartFile.isEmpty()) {
@@ -69,7 +83,7 @@ public class CardServiceImpl implements CardService {
                         .fileUrl(fileUrl)
                         .sequence(prevCard.getSequence())
                         .deadline(cardUpdateReq.getDeadline())
-                        .categoryId(prevCard.getCategoryId())
+                        .category(prevCard.getCategory())
                         .build());
         return new CardUpdateRes();
     }
@@ -77,9 +91,10 @@ public class CardServiceImpl implements CardService {
     @Override
     @Transactional
     public CardDeleteRes deleteCard(CardDeleteReq cardDeleteReq) {
-        // TODO ADD Team check
-        Card card = cardRepository.findByCardId(cardDeleteReq.getCardId());
-        CardValidator.validate(card);
+        User user = getUserByUsername(cardDeleteReq.getUsername());
+        Card card = getCardByCardId(cardDeleteReq.getCardId());
+        TeamRoleValidator.checkIsTeamMember(card.getCategory().getTeam().getTeamRoleList(), user);
+
         deleteFile(card.getFileUrl());
         cardRepository.delete(card);
         return new CardDeleteRes();
@@ -94,18 +109,21 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional(readOnly = true)
-    public CardGetRes getCard(Long cardId) {
-        // TODO ADD Team check
-        return CardServiceMapper.INSTANCE.toCardGetRes(cardRepository.findByCardId(cardId));
+    public CardGetRes getCard(Long cardId, String username) {
+        User user = getUserByUsername(username);
+        Card card = getCardByCardId(cardId);
+        TeamRoleValidator.checkIsTeamMember(card.getCategory().getTeam().getTeamRoleList(), user);
+        return CardServiceMapper.INSTANCE.toCardGetRes(card);
     }
 
     @Override
     @Transactional
     public CardChangeSequenceRes changeSequence(CardChangeSequenceReq cardChangeSequenceReq) {
-        // TODO ADD Team check
-        // TODO ADD Category null check
-        Card card = cardRepository.findByCardId(cardChangeSequenceReq.getCardId());
-        CardValidator.validate(card);
+        User user = getUserByUsername(cardChangeSequenceReq.getUsername());
+        Card card = getCardByCardId(cardChangeSequenceReq.getCardId());
+        Category category = categoryRepository.findByCategoryId(cardChangeSequenceReq.getCategoryId());
+        CategoryValidator.validate(category);
+        TeamRoleValidator.checkIsTeamMember(category.getTeam().getTeamRoleList(), user);
 
         Double averageSequence =
                 getAverageSequence(
@@ -119,7 +137,7 @@ public class CardServiceImpl implements CardService {
                         .fileUrl(card.getFileUrl())
                         .sequence(averageSequence)
                         .deadline(card.getDeadline())
-                        .categoryId(cardChangeSequenceReq.getCategoryId())
+                        .category(category)
                         .build());
 
         return new CardChangeSequenceRes();
@@ -127,5 +145,17 @@ public class CardServiceImpl implements CardService {
 
     private Double getAverageSequence(Double preSequence, Double postSequence) {
         return (preSequence + postSequence) / 2;
+    }
+
+    private User getUserByUsername(String username) {
+        User user = userRepository.findByUsername(username);
+        UserValidator.validate(user);
+        return user;
+    }
+
+    private Card getCardByCardId(Long cardId) {
+        Card card = cardRepository.findByCardId(cardId);
+        CardValidator.validate(card);
+        return card;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImpl.java
@@ -27,7 +27,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class CardServiceImpl implements CardService {
     private final CardRepository cardRepository;
     private final S3Util s3Util;
-    private final Double NEXT_SEQUENCE = 1.0;
 
     @Override
     @Transactional
@@ -48,7 +47,7 @@ public class CardServiceImpl implements CardService {
     }
 
     private Double getMaxSequence(Long categoryId) {
-        return cardRepository.getMaxSequence(categoryId) + NEXT_SEQUENCE;
+        return cardRepository.getMaxSequence(categoryId);
     }
 
     @Override

--- a/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryDeleteReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryDeleteReq.java
@@ -14,8 +14,7 @@ public class CategoryDeleteReq {
     private String username;
 
     @Builder
-    private CategoryDeleteReq(Long categoryId, String username) {
+    private CategoryDeleteReq(Long categoryId) {
         this.categoryId = categoryId;
-        this.username = username;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryEditReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryEditReq.java
@@ -15,9 +15,8 @@ public class CategoryEditReq {
     private String username;
 
     @Builder
-    private CategoryEditReq(Long categoryId, String name, String username) {
+    private CategoryEditReq(Long categoryId, String name) {
         this.categoryId = categoryId;
         this.name = name;
-        this.username = username;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategorySaveReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategorySaveReq.java
@@ -15,9 +15,8 @@ public class CategorySaveReq {
     private String username;
 
     @Builder
-    private CategorySaveReq(Long teamId, String name, String username) {
+    private CategorySaveReq(Long teamId, String name) {
         this.teamId = teamId;
         this.name = name;
-        this.username = username;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/team/entity/Team.java
+++ b/src/main/java/com/vt/valuetogether/domain/team/entity/Team.java
@@ -42,11 +42,13 @@ public class Team extends BaseEntity {
             String teamName,
             String teamDescription,
             String backgroundColor,
-            boolean isDeleted) {
+            boolean isDeleted,
+            List<TeamRole> teamRoleList) {
         this.teamId = teamId;
         this.teamName = teamName;
         this.teamDescription = teamDescription;
         this.backgroundColor = backgroundColor;
         this.isDeleted = isDeleted;
+        this.teamRoleList = teamRoleList;
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/card/controller/CardControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/controller/CardControllerTest.java
@@ -74,7 +74,8 @@ class CardControllerTest extends BaseMvcTest {
         CardSaveRes cardSaveRes = CardSaveRes.builder().cardId(cardId).build();
         when(cardService.saveCard(any(), any())).thenReturn(cardSaveRes);
         this.mockMvc
-                .perform(multipart("/api/v1/cards").file(multipartFile).file(req))
+                .perform(
+                        multipart("/api/v1/cards").file(multipartFile).file(req).principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -112,7 +113,11 @@ class CardControllerTest extends BaseMvcTest {
         CardUpdateRes cardUpdateRes = new CardUpdateRes();
         when(cardService.updateCard(any(), any())).thenReturn(cardUpdateRes);
         this.mockMvc
-                .perform(multipart(PATCH, "/api/v1/cards").file(multipartFile).file(req))
+                .perform(
+                        multipart(PATCH, "/api/v1/cards")
+                                .file(multipartFile)
+                                .file(req)
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -128,7 +133,8 @@ class CardControllerTest extends BaseMvcTest {
                 .perform(
                         delete("/api/v1/cards")
                                 .contentType(APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(cardDeleteReq)))
+                                .content(objectMapper.writeValueAsString(cardDeleteReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -161,8 +167,11 @@ class CardControllerTest extends BaseMvcTest {
                         .deadline(deadline)
                         .checklists(checklists)
                         .build();
-        when(cardService.getCard(any())).thenReturn(cardGetRes);
-        this.mockMvc.perform(get("/api/v1/cards/" + cardId)).andDo(print()).andExpect(status().isOk());
+        when(cardService.getCard(any(), any())).thenReturn(cardGetRes);
+        this.mockMvc
+                .perform(get("/api/v1/cards/" + cardId).principal(this.mockPrincipal))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -180,15 +189,14 @@ class CardControllerTest extends BaseMvcTest {
                         .postSequence(postSeq)
                         .build();
 
-        String json = objectMapper.writeValueAsString(cardChangeSequenceReq);
-
         CardChangeSequenceRes cardChangeSequenceRes = new CardChangeSequenceRes();
         when(cardService.changeSequence(any())).thenReturn(cardChangeSequenceRes);
         this.mockMvc
                 .perform(
                         patch("/api/v1/cards/order")
                                 .contentType(APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(cardChangeSequenceRes)))
+                                .content(objectMapper.writeValueAsString(cardChangeSequenceRes))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/repository/CardRepositoryTest.java
@@ -3,6 +3,8 @@ package com.vt.valuetogether.domain.card.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.vt.valuetogether.domain.card.entity.Card;
+import com.vt.valuetogether.domain.category.repository.CategoryRepository;
+import com.vt.valuetogether.domain.team.repository.TeamRepository;
 import com.vt.valuetogether.test.CardTest;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -17,11 +19,15 @@ import org.springframework.test.context.ActiveProfiles;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class CardRepositoryTest implements CardTest {
     @Autowired private CardRepository cardRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TeamRepository teamRepository;
 
     @Test
     @DisplayName("card 저장 테스트")
     void card_저장() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
 
         // when
         Card card = cardRepository.save(TEST_CARD);
@@ -39,19 +45,23 @@ class CardRepositoryTest implements CardTest {
     void categoryId_max_sequence_조회() {
         // given
         Long categoryId = 1L;
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         Card saveCard = cardRepository.save(TEST_CARD);
 
         // when
         Double maxSequence = cardRepository.getMaxSequence(categoryId);
 
         // then
-        assertThat(maxSequence).isEqualTo(saveCard.getSequence());
+        assertThat(maxSequence).isEqualTo(saveCard.getSequence() + 1.0);
     }
 
     @Test
     @DisplayName("id로 card 조회 테스트")
     void id_card_조회() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         Card saveCard = cardRepository.save(TEST_CARD);
 
         // when
@@ -69,6 +79,8 @@ class CardRepositoryTest implements CardTest {
     @DisplayName("card 삭제 테스트")
     void card_삭제() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         cardRepository.save(TEST_CARD);
 
         // when
@@ -83,11 +95,13 @@ class CardRepositoryTest implements CardTest {
     @DisplayName("categoryId별 card list 조회 테스트")
     void categoryId_card_list_조회() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         Card saveCard = cardRepository.save(TEST_CARD);
         Card saveAnotherCard = cardRepository.save(TEST_ANOTHER_CARD);
 
         // when
-        List<Card> cards = cardRepository.findByOrderByCategoryIdAscSequenceAsc();
+        List<Card> cards = cardRepository.findByOrderByCategoryCategoryIdAscSequenceAsc();
 
         // then
         assertThat(cards.get(0).getName()).isEqualTo(saveCard.getName());
@@ -106,6 +120,8 @@ class CardRepositoryTest implements CardTest {
     @DisplayName("cards 저장 테스트")
     void cards_저장() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         List<Card> cards = List.of(TEST_CARD, TEST_ANOTHER_CARD);
 
         // when

--- a/src/test/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/service/impl/CardServiceImplTest.java
@@ -2,7 +2,6 @@ package com.vt.valuetogether.domain.card.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -16,12 +15,20 @@ import com.vt.valuetogether.domain.card.dto.request.CardUpdateReq;
 import com.vt.valuetogether.domain.card.dto.response.CardGetRes;
 import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.domain.card.repository.CardRepository;
+import com.vt.valuetogether.domain.category.entity.Category;
+import com.vt.valuetogether.domain.category.repository.CategoryRepository;
+import com.vt.valuetogether.domain.team.entity.Team;
+import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.infra.s3.S3Util;
 import com.vt.valuetogether.test.CardTest;
+import com.vt.valuetogether.test.TeamRoleTest;
+import com.vt.valuetogether.test.UserTest;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,11 +40,47 @@ import org.springframework.core.io.Resource;
 import org.springframework.mock.web.MockMultipartFile;
 
 @ExtendWith(MockitoExtension.class)
-class CardServiceImplTest implements CardTest {
+class CardServiceImplTest implements CardTest, UserTest, TeamRoleTest {
     @InjectMocks private CardServiceImpl cardService;
 
     @Mock private CardRepository cardRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private UserRepository userRepository;
     @Mock private S3Util s3Util;
+    private Category category;
+    private Team team;
+    private Card card;
+
+    @BeforeEach
+    void setUp() {
+        team =
+                Team.builder()
+                        .teamId(TEST_TEAM_ID)
+                        .teamName(TEST_TEAM_NAME)
+                        .teamDescription(TEST_TEAM_DESCRIPTION)
+                        .backgroundColor(TEST_BACKGROUND_COLOR)
+                        .isDeleted(TEST_TEAM_IS_DELETED)
+                        .teamRoleList(List.of(TEST_TEAM_ROLE))
+                        .build();
+        category =
+                Category.builder()
+                        .categoryId(TEST_CATEGORY_ID)
+                        .name(TEST_CATEGORY_NAME)
+                        .sequence(TEST_CATEGORY_SEQUENCE)
+                        .isDeleted(TEST_CATEGORY_IS_DELETED)
+                        .team(team)
+                        .build();
+        card =
+                Card.builder()
+                        .cardId(TEST_CARD_ID)
+                        .name(TEST_NAME)
+                        .description(TEST_DESCRIPTION)
+                        .fileUrl(TEST_FILE_URL)
+                        .sequence(TEST_SEQUENCE)
+                        .deadline(TEST_DEADLINE)
+                        .category(category)
+                        .build();
+    }
 
     @Test
     @DisplayName("card 저장 테스트")
@@ -63,14 +106,18 @@ class CardServiceImplTest implements CardTest {
                         fileResource.getFilename(),
                         IMAGE_JPEG.getType(),
                         fileResource.getInputStream());
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(categoryRepository.findByCategoryId(any())).thenReturn(category);
         when(cardRepository.getMaxSequence(any())).thenReturn(TEST_SEQUENCE);
-        when(cardRepository.save(any())).thenReturn(TEST_CARD);
+        when(cardRepository.save(any())).thenReturn(card);
         when(s3Util.uploadFile(any(), any())).thenReturn(TEST_FILE_URL);
 
         // when
         cardService.saveCard(cardSaveReq, multipartFile);
 
         // then
+        verify(userRepository).findByUsername(any());
+        verify(categoryRepository).findByCategoryId(any());
         verify(cardRepository).getMaxSequence(any());
         verify(cardRepository).save(any());
         verify(s3Util).uploadFile(any(), any());
@@ -100,7 +147,8 @@ class CardServiceImplTest implements CardTest {
                         fileResource.getFilename(),
                         IMAGE_JPEG.getType(),
                         fileResource.getInputStream());
-        when(cardRepository.findByCardId(any())).thenReturn(TEST_CARD);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(cardRepository.findByCardId(any())).thenReturn(card);
         when(cardRepository.save(any())).thenReturn(TEST_UPDATED_CARD);
         when(s3Util.uploadFile(any(), any())).thenReturn(TEST_FILE_URL);
 
@@ -108,6 +156,7 @@ class CardServiceImplTest implements CardTest {
         cardService.updateCard(cardUpdateReq, multipartFile);
 
         // then
+        verify(userRepository).findByUsername(any());
         verify(cardRepository).findByCardId(any());
         verify(cardRepository).save(any());
         verify(s3Util).uploadFile(any(), any());
@@ -119,12 +168,14 @@ class CardServiceImplTest implements CardTest {
         // given
         Long cardId = 1L;
         CardDeleteReq cardDeleteReq = CardDeleteReq.builder().cardId(cardId).build();
-        when(cardRepository.findByCardId(any())).thenReturn(TEST_CARD);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(cardRepository.findByCardId(any())).thenReturn(card);
 
         // when
         cardService.deleteCard(cardDeleteReq);
 
         // then
+        verify(userRepository).findByUsername(any());
         verify(cardRepository).findByCardId(any());
         verify(cardRepository).delete(any());
     }
@@ -134,18 +185,21 @@ class CardServiceImplTest implements CardTest {
     void card_단건_조회() {
         // given
         Long cardId = 1L;
+        String username = "ysys";
         ZonedDateTime zonedDateTime = TEST_DEADLINE.atZone(ZoneId.of("Asia/Seoul"));
         String deadline = zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        when(cardRepository.findByCardId(any())).thenReturn(TEST_CARD);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(cardRepository.findByCardId(any())).thenReturn(card);
 
         // when
-        CardGetRes cardGetRes = cardService.getCard(cardId);
+        CardGetRes cardGetRes = cardService.getCard(cardId, username);
 
         // then
         assertThat(cardGetRes.getName()).isEqualTo(TEST_NAME);
         assertThat(cardGetRes.getDescription()).isEqualTo(TEST_DESCRIPTION);
         assertThat(cardGetRes.getFileUrl()).isEqualTo(TEST_FILE_URL);
         assertThat(cardGetRes.getDeadline()).isEqualTo(deadline);
+        verify(userRepository).findByUsername(any());
         verify(cardRepository).findByCardId(any());
     }
 
@@ -166,12 +220,18 @@ class CardServiceImplTest implements CardTest {
                         .postSequence(postSequence)
                         .build();
 
-        given(cardRepository.findByCardId(anyLong())).willReturn(TEST_CARD);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        given(cardRepository.findByCardId(any())).willReturn(card);
+        when(categoryRepository.findByCategoryId(any())).thenReturn(category);
+        when(cardRepository.save(any())).thenReturn(TEST_ANOTHER_CARD);
 
         // when
         cardService.changeSequence(cardChangeSequenceReq);
 
         // then
+        verify(userRepository).findByUsername(any());
+        verify(cardRepository).findByCardId(any());
+        verify(categoryRepository).findByCategoryId(any());
         verify(cardRepository, times(1)).save(any(Card.class));
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
@@ -38,12 +38,11 @@ class CategoryRepositoryTest implements CategoryTest {
     @DisplayName("teamId로 max sequence 조회 테스트")
     void teamId_max_sequence_조회() {
         // given
-        Long teamId = 1L;
         teamRepository.save(TEST_TEAM);
         Category saveCategory = categoryRepository.save(TEST_CATEGORY);
 
         // when
-        Double maxSequence = categoryRepository.getMaxSequence(teamId);
+        Double maxSequence = categoryRepository.getMaxSequence(saveCategory.getTeam().getTeamId());
 
         // then
         assertThat(maxSequence).isEqualTo(saveCategory.getSequence() + 1.0);

--- a/src/test/java/com/vt/valuetogether/domain/checklist/repository/ChecklistRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/repository/ChecklistRepositoryTest.java
@@ -3,7 +3,9 @@ package com.vt.valuetogether.domain.checklist.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.vt.valuetogether.domain.card.repository.CardRepository;
+import com.vt.valuetogether.domain.category.repository.CategoryRepository;
 import com.vt.valuetogether.domain.checklist.entity.Checklist;
+import com.vt.valuetogether.domain.team.repository.TeamRepository;
 import com.vt.valuetogether.test.ChecklistTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,11 +20,15 @@ import org.springframework.test.context.ActiveProfiles;
 class ChecklistRepositoryTest implements ChecklistTest {
     @Autowired private ChecklistRepository checklistRepository;
     @Autowired private CardRepository cardRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TeamRepository teamRepository;
 
     @Test
     @DisplayName("checklist 저장 테스트")
     void checklist_저장() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         cardRepository.save(TEST_CARD);
 
         // when
@@ -36,6 +42,8 @@ class ChecklistRepositoryTest implements ChecklistTest {
     @DisplayName("id로 checklist 조회 테스트")
     void id_checklist_조회() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         cardRepository.save(TEST_CARD);
         Checklist saveChecklist = checklistRepository.save(TEST_CHECKLIST);
 
@@ -50,6 +58,8 @@ class ChecklistRepositoryTest implements ChecklistTest {
     @DisplayName("checklist 삭제 테스트")
     void checklist_삭제() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         cardRepository.save(TEST_CARD);
         Checklist saveChecklist = checklistRepository.save(TEST_CHECKLIST);
 

--- a/src/test/java/com/vt/valuetogether/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/comment/repository/CommentRepositoryTest.java
@@ -3,7 +3,9 @@ package com.vt.valuetogether.domain.comment.repository;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.vt.valuetogether.domain.card.repository.CardRepository;
+import com.vt.valuetogether.domain.category.repository.CategoryRepository;
 import com.vt.valuetogether.domain.comment.entity.Comment;
+import com.vt.valuetogether.domain.team.repository.TeamRepository;
 import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.test.CommentTest;
 import org.junit.jupiter.api.DisplayName;
@@ -23,11 +25,15 @@ class CommentRepositoryTest implements CommentTest {
     @Autowired private UserRepository userRepository;
 
     @Autowired private CardRepository cardRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TeamRepository teamRepository;
 
     @Test
     @DisplayName("save 테스트")
     void saveTest() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         userRepository.save(TEST_USER);
         cardRepository.save(TEST_CARD);
         Comment comment =

--- a/src/test/java/com/vt/valuetogether/domain/task/repository/TaskRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/task/repository/TaskRepositoryTest.java
@@ -3,8 +3,10 @@ package com.vt.valuetogether.domain.task.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.vt.valuetogether.domain.card.repository.CardRepository;
+import com.vt.valuetogether.domain.category.repository.CategoryRepository;
 import com.vt.valuetogether.domain.checklist.repository.ChecklistRepository;
 import com.vt.valuetogether.domain.task.entity.Task;
+import com.vt.valuetogether.domain.team.repository.TeamRepository;
 import com.vt.valuetogether.test.TaskTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,11 +22,15 @@ class TaskRepositoryTest implements TaskTest {
     @Autowired private ChecklistRepository checklistRepository;
     @Autowired private TaskRepository taskRepository;
     @Autowired private CardRepository cardRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TeamRepository teamRepository;
 
     @Test
     @DisplayName("task 저장 테스트")
     void task_저장() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         cardRepository.save(TEST_CARD);
         checklistRepository.save(TEST_CHECKLIST);
 
@@ -40,6 +46,8 @@ class TaskRepositoryTest implements TaskTest {
     @DisplayName("id로 task 조회 테스트")
     void id_task_조회() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         cardRepository.save(TEST_CARD);
         checklistRepository.save(TEST_CHECKLIST);
         Task saveTask = taskRepository.save(TEST_TASK);
@@ -56,6 +64,8 @@ class TaskRepositoryTest implements TaskTest {
     @DisplayName("task 삭제 테스트")
     void task_삭제() {
         // given
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         cardRepository.save(TEST_CARD);
         checklistRepository.save(TEST_CHECKLIST);
         Task saveTask = taskRepository.save(TEST_TASK);

--- a/src/test/java/com/vt/valuetogether/domain/worker/repository/WorkerRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/worker/repository/WorkerRepositoryTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.domain.card.repository.CardRepository;
+import com.vt.valuetogether.domain.category.repository.CategoryRepository;
+import com.vt.valuetogether.domain.team.repository.TeamRepository;
 import com.vt.valuetogether.domain.user.entity.User;
 import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.domain.worker.entity.Worker;
@@ -23,12 +25,16 @@ class WorkerRepositoryTest implements WorkerTest {
     @Autowired private UserRepository userRepository;
     @Autowired private CardRepository cardRepository;
     @Autowired private WorkerRepository workerRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TeamRepository teamRepository;
 
     @Test
     @DisplayName("worker 저장 테스트")
     void worker_저장() {
         // given
         User savedUser = userRepository.save(User.builder().build());
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         cardRepository.save(TEST_CARD);
 
         // when
@@ -43,6 +49,8 @@ class WorkerRepositoryTest implements WorkerTest {
     void id_worker_조회() {
         // given
         User savedUser = userRepository.save(TEST_USER);
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         Card savedCard = cardRepository.save(TEST_CARD);
         Worker savedWorker = workerRepository.save(TEST_WORKER);
 
@@ -58,6 +66,8 @@ class WorkerRepositoryTest implements WorkerTest {
     void worker_삭제() {
         // given
         User user = userRepository.save(User.builder().build());
+        teamRepository.save(TEST_TEAM);
+        categoryRepository.save(TEST_CATEGORY);
         Card card = cardRepository.save(Card.builder().build());
         Worker worker = workerRepository.save(Worker.builder().user(user).card(card).build());
 

--- a/src/test/java/com/vt/valuetogether/test/CardTest.java
+++ b/src/test/java/com/vt/valuetogether/test/CardTest.java
@@ -3,7 +3,7 @@ package com.vt.valuetogether.test;
 import com.vt.valuetogether.domain.card.entity.Card;
 import java.time.LocalDateTime;
 
-public interface CardTest {
+public interface CardTest extends CategoryTest {
 
     Long TEST_CARD_ID = 1L;
     String TEST_NAME = "name";
@@ -11,7 +11,6 @@ public interface CardTest {
     String TEST_FILE_URL = "url";
     Double TEST_SEQUENCE = 1.0;
     LocalDateTime TEST_DEADLINE = LocalDateTime.now();
-    Long TEST_CATEGORY_ID = 1L;
 
     String TEST_UPDATED_NAME = "updatedName";
     String TEST_UPDATED_DESCRIPTION = "updatedDescription";
@@ -33,7 +32,7 @@ public interface CardTest {
                     .fileUrl(TEST_FILE_URL)
                     .sequence(TEST_SEQUENCE)
                     .deadline(TEST_DEADLINE)
-                    .categoryId(TEST_CATEGORY_ID)
+                    .category(TEST_CATEGORY)
                     .build();
 
     Card TEST_UPDATED_CARD =
@@ -44,7 +43,7 @@ public interface CardTest {
                     .fileUrl(TEST_UPDATED_FILE_URL)
                     .sequence(TEST_SEQUENCE)
                     .deadline(TEST_UPDATED_DEADLINE)
-                    .categoryId(TEST_CATEGORY_ID)
+                    .category(TEST_CATEGORY)
                     .build();
 
     Card TEST_ANOTHER_CARD =
@@ -55,6 +54,6 @@ public interface CardTest {
                     .fileUrl(TEST_ANOTHER_FILE_URL)
                     .sequence(TEST_ANOTHER_SEQUENCE)
                     .deadline(TEST_ANOTHER_DEADLINE)
-                    .categoryId(TEST_CATEGORY_ID)
+                    .category(TEST_CATEGORY)
                     .build();
 }

--- a/src/test/java/com/vt/valuetogether/test/TeamRoleTest.java
+++ b/src/test/java/com/vt/valuetogether/test/TeamRoleTest.java
@@ -1,0 +1,19 @@
+package com.vt.valuetogether.test;
+
+import com.vt.valuetogether.domain.team.entity.Role;
+import com.vt.valuetogether.domain.team.entity.TeamRole;
+
+public interface TeamRoleTest extends TeamTest, UserTest {
+    Long TEST_TEAM_ROLE_ID = 1L;
+    Role TEST_TEAM_ROLE_ROLE = Role.LEADER;
+    boolean TEST_TEAM_ROLE_IS_DELETED = false;
+
+    TeamRole TEST_TEAM_ROLE =
+            TeamRole.builder()
+                    .teamRoleId(TEST_TEAM_ROLE_ID)
+                    .user(TEST_USER)
+                    .team(TEST_TEAM)
+                    .role(TEST_TEAM_ROLE_ROLE)
+                    .isDeleted(TEST_TEAM_ROLE_IS_DELETED)
+                    .build();
+}


### PR DESCRIPTION
## 개요
card api에 team validator를 추가합니다.

## 작업사항
- card entity의 categoryId를 category entity로 변경합니다.
- team entity의 builder에 teamrole list를 추가합니다.
- card api에 userDetails를 추가합니다.
- 위 변경사항에 따라 일부 로직과 테스트코드를 수정합니다.

## 관련 이슈
- close #90
