### PR TITLE
category sequence 변경 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -142,6 +142,7 @@ endif::[]
 == category API
 
 include::{snippets}/category-controller-test/category_저장/auto-section.adoc[]
+include::{snippets}/category-controller-test/category_순서_변경/auto-section.adoc[]
 
 == card API
 

--- a/src/main/java/com/vt/valuetogether/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/controller/CategoryController.java
@@ -1,8 +1,10 @@
 package com.vt.valuetogether.domain.category.controller;
 
+import com.vt.valuetogether.domain.category.dto.request.CategoryChangeSequenceReq;
 import com.vt.valuetogether.domain.category.dto.request.CategoryDeleteReq;
 import com.vt.valuetogether.domain.category.dto.request.CategoryEditReq;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
+import com.vt.valuetogether.domain.category.dto.response.CategoryChangeSequenceRes;
 import com.vt.valuetogether.domain.category.dto.response.CategoryDeleteRes;
 import com.vt.valuetogether.domain.category.dto.response.CategoryEditRes;
 import com.vt.valuetogether.domain.category.dto.response.CategorySaveRes;
@@ -45,5 +47,13 @@ public class CategoryController {
             @RequestBody CategoryDeleteReq req, @AuthenticationPrincipal UserDetails userDetails) {
         req.setUsername(userDetails.getUsername());
         return RestResponse.success(categoryService.deleteCategory(req));
+    }
+
+    @PatchMapping("/order")
+    public RestResponse<CategoryChangeSequenceRes> changeCategorySequence(
+            @RequestBody CategoryChangeSequenceReq categoryChangeSequenceReq,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        categoryChangeSequenceReq.setUsername(userDetails.getUsername());
+        return RestResponse.success(categoryService.changeCategorySequence(categoryChangeSequenceReq));
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryChangeSequenceReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/request/CategoryChangeSequenceReq.java
@@ -1,0 +1,24 @@
+package com.vt.valuetogether.domain.category.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategoryChangeSequenceReq {
+    private Long categoryId;
+    private Double preSequence;
+    private Double postSequence;
+    private String username;
+
+    @Builder
+    public CategoryChangeSequenceReq(Long categoryId, Double preSequence, Double postSequence) {
+        this.categoryId = categoryId;
+        this.preSequence = preSequence;
+        this.postSequence = postSequence;
+    }
+}

--- a/src/main/java/com/vt/valuetogether/domain/category/dto/response/CategoryChangeSequenceRes.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/response/CategoryChangeSequenceRes.java
@@ -1,0 +1,6 @@
+package com.vt.valuetogether.domain.category.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class CategoryChangeSequenceRes {}

--- a/src/main/java/com/vt/valuetogether/domain/category/service/CategoryService.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/CategoryService.java
@@ -1,8 +1,10 @@
 package com.vt.valuetogether.domain.category.service;
 
+import com.vt.valuetogether.domain.category.dto.request.CategoryChangeSequenceReq;
 import com.vt.valuetogether.domain.category.dto.request.CategoryDeleteReq;
 import com.vt.valuetogether.domain.category.dto.request.CategoryEditReq;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
+import com.vt.valuetogether.domain.category.dto.response.CategoryChangeSequenceRes;
 import com.vt.valuetogether.domain.category.dto.response.CategoryDeleteRes;
 import com.vt.valuetogether.domain.category.dto.response.CategoryEditRes;
 import com.vt.valuetogether.domain.category.dto.response.CategorySaveRes;
@@ -13,4 +15,7 @@ public interface CategoryService {
     CategoryEditRes editCategory(CategoryEditReq req);
 
     CategoryDeleteRes deleteCategory(CategoryDeleteReq req);
+
+    CategoryChangeSequenceRes changeCategorySequence(
+            CategoryChangeSequenceReq categoryChangeSequenceReq);
 }

--- a/src/test/java/com/vt/valuetogether/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/controller/CategoryControllerTest.java
@@ -3,12 +3,15 @@ package com.vt.valuetogether.domain.category.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.vt.valuetogether.domain.BaseMvcTest;
+import com.vt.valuetogether.domain.category.dto.request.CategoryChangeSequenceReq;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
+import com.vt.valuetogether.domain.category.dto.response.CategoryChangeSequenceRes;
 import com.vt.valuetogether.domain.category.dto.response.CategorySaveRes;
 import com.vt.valuetogether.domain.category.service.CategoryService;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +38,30 @@ class CategoryControllerTest extends BaseMvcTest {
                                 .contentType(APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(categorySaveReq))
                                 .principal(mockPrincipal))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("category 순서 변경 테스트")
+    void category_순서_변경() throws Exception {
+        Long categoryId = 1L;
+        Double preSequence = 2.0;
+        Double postSequence = 3.0;
+        CategoryChangeSequenceReq categoryChangeSequenceReq =
+                CategoryChangeSequenceReq.builder()
+                        .categoryId(categoryId)
+                        .preSequence(preSequence)
+                        .postSequence(postSequence)
+                        .build();
+        CategoryChangeSequenceRes categoryChangeSequenceRes = new CategoryChangeSequenceRes();
+        when(categoryService.changeCategorySequence(any())).thenReturn(categoryChangeSequenceRes);
+        this.mockMvc
+                .perform(
+                        patch("/api/v1/categories/order")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(categoryChangeSequenceReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImplTest.java
@@ -1,19 +1,16 @@
 package com.vt.valuetogether.domain.category.service.impl;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.vt.valuetogether.domain.card.entity.Card;
+import com.vt.valuetogether.domain.category.dto.request.CategoryChangeSequenceReq;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
 import com.vt.valuetogether.domain.category.entity.Category;
 import com.vt.valuetogether.domain.category.repository.CategoryRepository;
 import com.vt.valuetogether.domain.team.entity.Team;
 import com.vt.valuetogether.domain.team.repository.TeamRepository;
-import com.vt.valuetogether.domain.team.repository.TeamRoleRepository;
 import com.vt.valuetogether.domain.user.repository.UserRepository;
-import com.vt.valuetogether.global.exception.GlobalException;
 import com.vt.valuetogether.test.CategoryTest;
 import com.vt.valuetogether.test.TeamRoleTest;
 import com.vt.valuetogether.test.UserTest;
@@ -33,19 +30,28 @@ class CategoryServiceImplTest implements CategoryTest, UserTest, TeamRoleTest {
     @Mock private CategoryRepository categoryRepository;
     @Mock private TeamRepository teamRepository;
     @Mock private UserRepository userRepository;
+    private Category category;
     private Team team;
 
     @BeforeEach
     void setUp() {
         team =
-            Team.builder()
-                .teamId(TEST_TEAM_ID)
-                .teamName(TEST_TEAM_NAME)
-                .teamDescription(TEST_TEAM_DESCRIPTION)
-                .backgroundColor(TEST_BACKGROUND_COLOR)
-                .isDeleted(TEST_TEAM_IS_DELETED)
-                .teamRoleList(List.of(TEST_TEAM_ROLE))
-                .build();
+                Team.builder()
+                        .teamId(TEST_TEAM_ID)
+                        .teamName(TEST_TEAM_NAME)
+                        .teamDescription(TEST_TEAM_DESCRIPTION)
+                        .backgroundColor(TEST_BACKGROUND_COLOR)
+                        .isDeleted(TEST_TEAM_IS_DELETED)
+                        .teamRoleList(List.of(TEST_TEAM_ROLE))
+                        .build();
+        category =
+                Category.builder()
+                        .categoryId(TEST_CATEGORY_ID)
+                        .name(TEST_CATEGORY_NAME)
+                        .sequence(TEST_CATEGORY_SEQUENCE)
+                        .isDeleted(TEST_CATEGORY_IS_DELETED)
+                        .team(team)
+                        .build();
     }
 
     @Test
@@ -67,6 +73,32 @@ class CategoryServiceImplTest implements CategoryTest, UserTest, TeamRoleTest {
         verify(userRepository).findByUsername(any());
         verify(teamRepository).findByTeamId(any());
         verify(categoryRepository).getMaxSequence(any());
+        verify(categoryRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("category 순서 변경 테스트")
+    void category_순서_변경() {
+        // given
+        Long categoryId = 1L;
+        Double preSequence = 2.0;
+        Double postSequence = 3.0;
+        CategoryChangeSequenceReq categoryChangeSequenceReq =
+                CategoryChangeSequenceReq.builder()
+                        .categoryId(categoryId)
+                        .preSequence(preSequence)
+                        .postSequence(postSequence)
+                        .build();
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(categoryRepository.findByCategoryId(any())).thenReturn(category);
+        when(categoryRepository.save(any())).thenReturn(category);
+
+        // when
+        categoryService.changeCategorySequence(categoryChangeSequenceReq);
+
+        // then
+        verify(userRepository).findByUsername(any());
+        verify(categoryRepository).findByCategoryId(any());
         verify(categoryRepository).save(any());
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImplTest.java
@@ -5,14 +5,20 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.domain.category.dto.request.CategorySaveReq;
+import com.vt.valuetogether.domain.category.entity.Category;
 import com.vt.valuetogether.domain.category.repository.CategoryRepository;
+import com.vt.valuetogether.domain.team.entity.Team;
 import com.vt.valuetogether.domain.team.repository.TeamRepository;
 import com.vt.valuetogether.domain.team.repository.TeamRoleRepository;
 import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.global.exception.GlobalException;
 import com.vt.valuetogether.test.CategoryTest;
+import com.vt.valuetogether.test.TeamRoleTest;
 import com.vt.valuetogether.test.UserTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,13 +27,26 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class CategoryServiceImplTest implements CategoryTest, UserTest {
+class CategoryServiceImplTest implements CategoryTest, UserTest, TeamRoleTest {
     @InjectMocks private CategoryServiceImpl categoryService;
 
     @Mock private CategoryRepository categoryRepository;
     @Mock private TeamRepository teamRepository;
     @Mock private UserRepository userRepository;
-    @Mock private TeamRoleRepository teamRoleRepository;
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team =
+            Team.builder()
+                .teamId(TEST_TEAM_ID)
+                .teamName(TEST_TEAM_NAME)
+                .teamDescription(TEST_TEAM_DESCRIPTION)
+                .backgroundColor(TEST_BACKGROUND_COLOR)
+                .isDeleted(TEST_TEAM_IS_DELETED)
+                .teamRoleList(List.of(TEST_TEAM_ROLE))
+                .build();
+    }
 
     @Test
     @DisplayName("category 저장 테스트")
@@ -37,18 +56,17 @@ class CategoryServiceImplTest implements CategoryTest, UserTest {
         String name = "category";
         CategorySaveReq categorySaveReq = CategorySaveReq.builder().teamId(teamId).name(name).build();
         when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
-        when(teamRepository.findByTeamId(any())).thenReturn(TEST_TEAM);
-        //        when(categoryRepository.getMaxSequence(any())).thenReturn(TEST_CATEGORY_SEQUENCE);
-        //        when(categoryRepository.save(any())).thenReturn(TEST_CATEGORY);
+        when(teamRepository.findByTeamId(any())).thenReturn(team);
+        when(categoryRepository.getMaxSequence(any())).thenReturn(TEST_CATEGORY_SEQUENCE);
+        when(categoryRepository.save(any())).thenReturn(TEST_CATEGORY);
 
         // when
+        categoryService.saveCategory(categorySaveReq);
 
         // then
-        assertThatThrownBy(() -> categoryService.saveCategory(categorySaveReq))
-                .isInstanceOf(GlobalException.class);
         verify(userRepository).findByUsername(any());
         verify(teamRepository).findByTeamId(any());
-        //        verify(categoryRepository).getMaxSequence(any());
-        //        verify(categoryRepository).save(any());
+        verify(categoryRepository).getMaxSequence(any());
+        verify(categoryRepository).save(any());
     }
 }


### PR DESCRIPTION
## 개요
category sequence 변경 api를 추가합니다.

## 작업사항
- category sequence 변경 api 추가
- 테스트코드 추가
- restdocs 추가

## 관련 이슈
- close #107 
