### PR TITLE
Fix/catch expired token

### DIFF
--- a/src/main/java/com/vt/valuetogether/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/vt/valuetogether/global/jwt/JwtAuthenticationFilter.java
@@ -86,7 +86,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         response.addHeader(JwtUtil.ACCESS_TOKEN_HEADER, accessToken);
         response.addHeader(JwtUtil.REFRESH_TOKEN_HEADER, refreshToken);
 
-        redisUtil.set(jwtUtil.substringToken(refreshToken), username, REFRESH_TOKEN_TIME);
+        redisUtil.set(jwtUtil.substringToken(accessToken), username, ACCESS_TOKEN_EXPIRED_TIME);
 
         return new UserLocalLoginRes();
     }

--- a/src/main/java/com/vt/valuetogether/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/vt/valuetogether/global/jwt/JwtAuthenticationFilter.java
@@ -96,8 +96,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             HttpServletRequest request, HttpServletResponse response, AuthenticationException failed)
             throws IOException {
 
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-
+        log.info("login failed message : {}", failed.getMessage());
+        response.setStatus(NOT_FOUND_USER.getStatus().value());
         settingResponse(response, RestResponse.error(NOT_FOUND_USER));
     }
 

--- a/src/main/java/com/vt/valuetogether/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/vt/valuetogether/global/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.vt.valuetogether.global.jwt;
 
 import static com.vt.valuetogether.global.meta.ResultCode.NOT_FOUND_USER;
 import static com.vt.valuetogether.global.meta.ResultCode.SYSTEM_ERROR;
+import static com.vt.valuetogether.global.redis.RedisUtil.ACCESS_TOKEN_EXPIRED_TIME;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vt.valuetogether.domain.user.dto.request.UserLocalLoginReq;
@@ -20,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -32,7 +32,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
-    private static final int REFRESH_TOKEN_TIME = 60 * 24 * 14;
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -49,7 +48,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         try {
             UserLocalLoginReq req =
                     new ObjectMapper().readValue(request.getInputStream(), UserLocalLoginReq.class);
-
+            log.info("[login try] username : {}, password : {}", req.getUsername(), req.getPassword());
             return getAuthenticationManager()
                     .authenticate(
                             new UsernamePasswordAuthenticationToken(req.getUsername(), req.getPassword(), null));
@@ -67,6 +66,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             Authentication authResult)
             throws IOException {
 
+        log.info("success auth username : {}", authResult.getName());
         UserLocalLoginRes res = addTokensInHeader(authResult, response);
         settingResponse(response, RestResponse.success(res));
     }

--- a/src/main/java/com/vt/valuetogether/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/vt/valuetogether/global/jwt/JwtAuthorizationFilter.java
@@ -33,7 +33,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private static final List<RequestMatcher> whiteList =
-            List.of(new AntPathRequestMatcher("/api/v1/users/signup", HttpMethod.POST.name()));
+            List.of(new AntPathRequestMatcher("/api/v1/users/signup/**", HttpMethod.POST.name()));
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
     private final UserDetailsService userDetailsService;

--- a/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
+++ b/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
@@ -84,6 +84,8 @@ public class JwtUtil {
         try {
             jwtParser.parseClaimsJws(token);
             return true;
+        } catch (ExpiredJwtException e) {
+            return true;
         } catch (SecurityException | MalformedJwtException | SignatureException e) {
             log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
         } catch (UnsupportedJwtException e) {

--- a/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
+++ b/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
@@ -110,4 +110,8 @@ public class JwtUtil {
     public Claims getUserInfoFromToken(String token) {
         return jwtParser.parseClaimsJws(token).getBody();
     }
+
+    public String getUsernameFromToken(String token) {
+        return getUserInfoFromToken(token).getSubject();
+    }
 }

--- a/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
+++ b/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
@@ -43,39 +43,33 @@ public class JwtUtil {
         jwtParser = Jwts.parserBuilder().setSigningKey(key).build();
     }
 
-    /**
-     * AccessToken 생성
-     */
+    /** AccessToken 생성 */
     public String createAccessToken(String username, String role) {
         Date now = new Date();
 
         return BEARER_PREFIX
-            + Jwts.builder()
-            .setSubject(username) // 사용자 식별자값(ID)
-            .claim(AUTHORIZATION_KEY, role) // 사용자 권한
-            .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_TIME)) // 만료 시간
-            .setIssuedAt(now) // 발급일
-            .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘 (HS256)
-            .compact();
+                + Jwts.builder()
+                        .setSubject(username) // 사용자 식별자값(ID)
+                        .claim(AUTHORIZATION_KEY, role) // 사용자 권한
+                        .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_TIME)) // 만료 시간
+                        .setIssuedAt(now) // 발급일
+                        .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘 (HS256)
+                        .compact();
     }
 
-    /**
-     * RefreshToken 생성
-     */
+    /** RefreshToken 생성 */
     public String createRefreshToken() {
         Date now = new Date();
 
         return BEARER_PREFIX
-            + Jwts.builder()
-            .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_TIME)) // 만료 시간
-            .setIssuedAt(now) // 발급일
-            .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘 (HS256)
-            .compact();
+                + Jwts.builder()
+                        .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_TIME)) // 만료 시간
+                        .setIssuedAt(now) // 발급일
+                        .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘 (HS256)
+                        .compact();
     }
 
-    /**
-     * JWT 토큰 substring
-     */
+    /** JWT 토큰 substring */
     public String substringToken(String token) {
         TokenValidator.checkValidToken(hasTokenBearerPrefix(token));
         return token.substring(7);
@@ -85,9 +79,7 @@ public class JwtUtil {
         return StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX);
     }
 
-    /**
-     * 토큰 검증, 만료 토큰은 검증하지 않음
-     */
+    /** 토큰 검증, 만료 토큰은 검증하지 않음 */
     public boolean isTokenValid(String token) {
         try {
             jwtParser.parseClaimsJws(token);
@@ -104,9 +96,7 @@ public class JwtUtil {
         return false;
     }
 
-    /**
-     * 토큰 만료 여부 검증.
-     */
+    /** 토큰 만료 여부 검증. */
     public boolean isTokenExpired(String token) {
         try {
             jwtParser.parseClaimsJws(token);
@@ -116,9 +106,7 @@ public class JwtUtil {
         return false;
     }
 
-    /**
-     * 토큰에서 사용자 정보 가져오기
-     */
+    /** 토큰에서 사용자 정보 가져오기 */
     public Claims getUserInfoFromToken(String token) {
         return jwtParser.parseClaimsJws(token).getBody();
     }

--- a/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
+++ b/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
@@ -43,33 +43,39 @@ public class JwtUtil {
         jwtParser = Jwts.parserBuilder().setSigningKey(key).build();
     }
 
-    /** AccessToken 생성 */
+    /**
+     * AccessToken 생성
+     */
     public String createAccessToken(String username, String role) {
         Date now = new Date();
 
         return BEARER_PREFIX
-                + Jwts.builder()
-                        .setSubject(username) // 사용자 식별자값(ID)
-                        .claim(AUTHORIZATION_KEY, role) // 사용자 권한
-                        .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_TIME)) // 만료 시간
-                        .setIssuedAt(now) // 발급일
-                        .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘 (HS256)
-                        .compact();
+            + Jwts.builder()
+            .setSubject(username) // 사용자 식별자값(ID)
+            .claim(AUTHORIZATION_KEY, role) // 사용자 권한
+            .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_TIME)) // 만료 시간
+            .setIssuedAt(now) // 발급일
+            .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘 (HS256)
+            .compact();
     }
 
-    /** RefreshToken 생성 */
+    /**
+     * RefreshToken 생성
+     */
     public String createRefreshToken() {
         Date now = new Date();
 
         return BEARER_PREFIX
-                + Jwts.builder()
-                        .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_TIME)) // 만료 시간
-                        .setIssuedAt(now) // 발급일
-                        .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘 (HS256)
-                        .compact();
+            + Jwts.builder()
+            .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_TIME)) // 만료 시간
+            .setIssuedAt(now) // 발급일
+            .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘 (HS256)
+            .compact();
     }
 
-    /** JWT 토큰 substring */
+    /**
+     * JWT 토큰 substring
+     */
     public String substringToken(String token) {
         TokenValidator.checkValidToken(hasTokenBearerPrefix(token));
         return token.substring(7);
@@ -79,7 +85,9 @@ public class JwtUtil {
         return StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX);
     }
 
-    /** 토큰 검증, 만료 토큰은 검증하지 않음 */
+    /**
+     * 토큰 검증, 만료 토큰은 검증하지 않음
+     */
     public boolean isTokenValid(String token) {
         try {
             jwtParser.parseClaimsJws(token);
@@ -96,7 +104,9 @@ public class JwtUtil {
         return false;
     }
 
-    /** 토큰 만료 여부 검증. */
+    /**
+     * 토큰 만료 여부 검증.
+     */
     public boolean isTokenExpired(String token) {
         try {
             jwtParser.parseClaimsJws(token);
@@ -106,12 +116,21 @@ public class JwtUtil {
         return false;
     }
 
-    /** 토큰에서 사용자 정보 가져오기 */
+    /**
+     * 토큰에서 사용자 정보 가져오기
+     */
     public Claims getUserInfoFromToken(String token) {
         return jwtParser.parseClaimsJws(token).getBody();
     }
 
     public String getUsernameFromToken(String token) {
         return getUserInfoFromToken(token).getSubject();
+    }
+
+    public String getTokenWithoutBearer(String token) {
+        if (token == null) {
+            return null;
+        }
+        return substringToken(token);
     }
 }

--- a/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
+++ b/src/main/java/com/vt/valuetogether/global/jwt/JwtUtil.java
@@ -97,9 +97,9 @@ public class JwtUtil {
     }
 
     /** 토큰 만료 여부 검증. */
-    public boolean isTokenExpired(String accessToken) {
+    public boolean isTokenExpired(String token) {
         try {
-            jwtParser.parseClaimsJws(accessToken);
+            jwtParser.parseClaimsJws(token);
         } catch (ExpiredJwtException e) {
             return true;
         }

--- a/src/main/java/com/vt/valuetogether/global/meta/ResultCode.java
+++ b/src/main/java/com/vt/valuetogether/global/meta/ResultCode.java
@@ -31,6 +31,7 @@ public enum ResultCode {
     INVALID_CODE(HttpStatus.BAD_REQUEST, 2010, "인증코드가 일치하지 않습니다."),
     INVALID_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, 2011, "올바르지 않은 로그인 접근입니다."),
     INVALID_PROFILE_IMAGE_FILE(HttpStatus.BAD_REQUEST, 2012, "이미지 파일만 업로드 가능합니다."),
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, 2013, "로그인이 필요합니다."),
 
     // 팀 3000번대
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, 3000, "존재하지 않는 팀입니다."),

--- a/src/main/java/com/vt/valuetogether/global/redis/RedisUtil.java
+++ b/src/main/java/com/vt/valuetogether/global/redis/RedisUtil.java
@@ -21,8 +21,11 @@ public class RedisUtil {
         return redisTemplate.opsForValue().get(key);
     }
 
-    public void delete(String key) {
-        redisTemplate.delete(key);
+    public boolean delete(String key) {
+        log.info("[delete] key {}", key);
+        boolean isDelete = Boolean.TRUE.equals(redisTemplate.delete(key));
+        log.info("[delete] isDelete : {}", isDelete);
+        return isDelete;
     }
 
     public boolean hasKey(String key) {

--- a/src/main/java/com/vt/valuetogether/global/redis/RedisUtil.java
+++ b/src/main/java/com/vt/valuetogether/global/redis/RedisUtil.java
@@ -2,10 +2,12 @@ package com.vt.valuetogether.global.redis;
 
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.stereotype.Component;
 
+@Slf4j(topic = "Redis Util")
 @Component
 @RequiredArgsConstructor
 public class RedisUtil {
@@ -14,12 +16,16 @@ public class RedisUtil {
     private final RedisTemplate<String, Object> redisTemplate;
 
     public void set(String key, Object o, int minutes) {
+        log.info("[set] key : {}, value : {}, time : {} minutes", key, o, minutes);
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(o.getClass()));
         redisTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
     }
 
     public Object get(String key) {
-        return redisTemplate.opsForValue().get(key);
+        log.info("[get] key : {}", key);
+        Object value = redisTemplate.opsForValue().get(key);
+        log.info("[get] value : {}", value);
+        return value;
     }
 
     public boolean delete(String key) {
@@ -30,6 +36,9 @@ public class RedisUtil {
     }
 
     public boolean hasKey(String key) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+        log.info("[hasKey] key : {}", key);
+        boolean hasKey = Boolean.TRUE.equals(redisTemplate.hasKey(key));
+        log.info("[hasKey] hasKey : {}", hasKey);
+        return hasKey;
     }
 }

--- a/src/main/java/com/vt/valuetogether/global/redis/RedisUtil.java
+++ b/src/main/java/com/vt/valuetogether/global/redis/RedisUtil.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RedisUtil {
 
+    public static final int ACCESS_TOKEN_EXPIRED_TIME = 60 * 24 * 14;
     private final RedisTemplate<String, Object> redisTemplate;
 
     public void set(String key, Object o, int minutes) {

--- a/src/main/java/com/vt/valuetogether/global/security/LogoutHandlerImpl.java
+++ b/src/main/java/com/vt/valuetogether/global/security/LogoutHandlerImpl.java
@@ -23,14 +23,15 @@ public class LogoutHandlerImpl implements LogoutHandler {
     public void logout(
             HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
 
-        String refreshToken = request.getHeader(JwtUtil.REFRESH_TOKEN_HEADER);
-        log.info("refresh token : {}", refreshToken);
-        refreshToken = jwtUtil.substringToken(refreshToken);
-        TokenValidator.checkValidToken(jwtUtil.isTokenValid(refreshToken));
+        String accessToken =
+                jwtUtil.getTokenWithoutBearer(request.getHeader(JwtUtil.ACCESS_TOKEN_HEADER));
+        log.info("access token : {}", accessToken);
 
-        if (redisUtil.hasKey(refreshToken)) {
-            log.info("delete redis refresh token : {}", refreshToken);
-            redisUtil.delete(refreshToken);
+        TokenValidator.checkValidToken(jwtUtil.isTokenValid(accessToken));
+
+        if (redisUtil.hasKey(accessToken)) {
+            log.info("delete redis access token : {}", accessToken);
+            redisUtil.delete(accessToken);
         }
     }
 }

--- a/src/main/java/com/vt/valuetogether/global/validator/TokenValidator.java
+++ b/src/main/java/com/vt/valuetogether/global/validator/TokenValidator.java
@@ -1,7 +1,7 @@
 package com.vt.valuetogether.global.validator;
 
-import static com.vt.valuetogether.global.meta.ResultCode.EXPIRED_TOKEN;
 import static com.vt.valuetogether.global.meta.ResultCode.INVALID_TOKEN;
+import static com.vt.valuetogether.global.meta.ResultCode.LOGIN_REQUIRED;
 
 import com.vt.valuetogether.global.exception.GlobalException;
 
@@ -13,9 +13,9 @@ public class TokenValidator {
         }
     }
 
-    public static void checkExpiredToken(boolean isTokenExpired) {
-        if (!isTokenExpired) {
-            throw new GlobalException(EXPIRED_TOKEN);
+    public static void checkLoginRequired(boolean isLoginRequired) {
+        if (isLoginRequired) {
+            throw new GlobalException(LOGIN_REQUIRED);
         }
     }
 }


### PR DESCRIPTION
## 개요
로그인, 로그아웃, 토큰 재발급 및 로그인 검증 로직 개편 

## 작업사항
- 만료 토큰 예외를 처리 못하던 버그 수정
- 레디스에 저장되는 키를 Refresh token 에서 Access token 으로 변경
- Access token이 유효하다면 Refresh token을 검증하지 않도록 수정 
- 로그인 요청 ResultCode 추가 

## 관련 이슈
- close #104 
