### PR TITLE
card 조회 시 담당자, 댓글 리스트 추가

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/card/dto/response/CardGetRes.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/dto/response/CardGetRes.java
@@ -1,6 +1,8 @@
 package com.vt.valuetogether.domain.card.dto.response;
 
 import com.vt.valuetogether.domain.checklist.dto.response.ChecklistGetRes;
+import com.vt.valuetogether.domain.comment.dto.response.CommentGetRes;
+import com.vt.valuetogether.domain.worker.dto.response.WorkerGetRes;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,7 +19,8 @@ public class CardGetRes {
     private Double sequence;
     private String deadline;
     private List<ChecklistGetRes> checklists;
-    // TODO ADD comments, workers
+    private List<WorkerGetRes> workers;
+    private List<CommentGetRes> comments;
 
     @Builder
     private CardGetRes(
@@ -27,7 +30,9 @@ public class CardGetRes {
             String fileUrl,
             Double sequence,
             String deadline,
-            List<ChecklistGetRes> checklists) {
+            List<ChecklistGetRes> checklists,
+            List<WorkerGetRes> workers,
+            List<CommentGetRes> comments) {
         this.cardId = cardId;
         this.name = name;
         this.description = description;
@@ -35,5 +40,7 @@ public class CardGetRes {
         this.sequence = sequence;
         this.deadline = deadline;
         this.checklists = checklists;
+        this.workers = workers;
+        this.comments = comments;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/card/entity/Card.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/entity/Card.java
@@ -49,7 +49,7 @@ public class Card extends BaseEntity {
     private List<Worker> workers;
 
     @OneToMany(mappedBy = "card", cascade = CascadeType.ALL)
-    @OrderBy("modifiedAt desc")
+    @OrderBy("createdAt desc")
     private List<Comment> comments;
 
     @Builder

--- a/src/main/java/com/vt/valuetogether/domain/card/entity/Card.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/entity/Card.java
@@ -2,6 +2,7 @@ package com.vt.valuetogether.domain.card.entity;
 
 import com.vt.valuetogether.domain.category.entity.Category;
 import com.vt.valuetogether.domain.checklist.entity.Checklist;
+import com.vt.valuetogether.domain.comment.entity.Comment;
 import com.vt.valuetogether.domain.model.BaseEntity;
 import com.vt.valuetogether.domain.worker.entity.Worker;
 import jakarta.persistence.CascadeType;
@@ -12,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,12 +42,15 @@ public class Card extends BaseEntity {
     @JoinColumn(name = "categoryId")
     private Category category;
 
-    // TODO ADD Comments
     @OneToMany(mappedBy = "card", cascade = CascadeType.ALL)
     private List<Checklist> checklists;
 
     @OneToMany(mappedBy = "card", cascade = CascadeType.ALL)
     private List<Worker> workers;
+
+    @OneToMany(mappedBy = "card", cascade = CascadeType.ALL)
+    @OrderBy("modifiedAt desc")
+    private List<Comment> comments;
 
     @Builder
     private Card(

--- a/src/main/java/com/vt/valuetogether/domain/card/service/CardServiceMapper.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/CardServiceMapper.java
@@ -3,6 +3,10 @@ package com.vt.valuetogether.domain.card.service;
 import com.vt.valuetogether.domain.card.dto.response.CardGetRes;
 import com.vt.valuetogether.domain.card.dto.response.CardSaveRes;
 import com.vt.valuetogether.domain.card.entity.Card;
+import com.vt.valuetogether.domain.comment.dto.response.CommentGetRes;
+import com.vt.valuetogether.domain.comment.entity.Comment;
+import com.vt.valuetogether.domain.worker.dto.response.WorkerGetRes;
+import com.vt.valuetogether.domain.worker.entity.Worker;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -23,6 +27,13 @@ public interface CardServiceMapper {
         ZonedDateTime zonedDateTime = deadline.atZone(ZoneId.of("Asia/Seoul"));
         return zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }
+
+    @Mapping(source = "user.username", target = "username")
+    CommentGetRes toCommentGetRes(Comment comment);
+
+    @Mapping(source = "user.profileImageUrl", target = "profileImageUrl")
+    @Mapping(source = "user.username", target = "username")
+    WorkerGetRes toWorkerGetRes(Worker worker);
 
     @Mapping(source = "deadline", target = "deadline")
     CardGetRes toCardGetRes(Card card);

--- a/src/main/java/com/vt/valuetogether/domain/comment/dto/response/CommentGetRes.java
+++ b/src/main/java/com/vt/valuetogether/domain/comment/dto/response/CommentGetRes.java
@@ -1,0 +1,21 @@
+package com.vt.valuetogether.domain.comment.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentGetRes {
+    private Long commentId;
+    private String content;
+    private String username;
+
+    @Builder
+    private CommentGetRes(Long commentId, String content, String username) {
+        this.commentId = commentId;
+        this.content = content;
+        this.username = username;
+    }
+}

--- a/src/test/java/com/vt/valuetogether/domain/card/controller/CardControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/card/controller/CardControllerTest.java
@@ -24,7 +24,9 @@ import com.vt.valuetogether.domain.card.dto.response.CardSaveRes;
 import com.vt.valuetogether.domain.card.dto.response.CardUpdateRes;
 import com.vt.valuetogether.domain.card.service.CardService;
 import com.vt.valuetogether.domain.checklist.dto.response.ChecklistGetRes;
+import com.vt.valuetogether.domain.comment.dto.response.CommentGetRes;
 import com.vt.valuetogether.domain.task.dto.response.TaskGetRes;
+import com.vt.valuetogether.domain.worker.dto.response.WorkerGetRes;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -143,11 +145,24 @@ class CardControllerTest extends BaseMvcTest {
     @DisplayName("card 단건 조회 테스트")
     void card_단건_조회() throws Exception {
         Long cardId = 1L;
+        String username = "ysys";
+        String profileImageUrl = "profileUrl";
+        WorkerGetRes workerGetRes =
+                WorkerGetRes.builder().username(username).profileImageUrl(profileImageUrl).build();
+        Long commentId = 1L;
+        String commentContent = "commentContent";
+        String commentUsername = "anotherUser";
+        CommentGetRes commentGetRes =
+                CommentGetRes.builder()
+                        .commentId(commentId)
+                        .content(commentContent)
+                        .username(commentUsername)
+                        .build();
         Long taskId = 1L;
-        String content = "taskContent";
+        String taskContent = "taskContent";
         Boolean isCompleted = false;
         TaskGetRes taskGetRes =
-                TaskGetRes.builder().taskId(taskId).content(content).isCompleted(isCompleted).build();
+                TaskGetRes.builder().taskId(taskId).content(taskContent).isCompleted(isCompleted).build();
         Long checklistId = 1L;
         String title = "checklistTitle";
         List<TaskGetRes> tasks = List.of(taskGetRes);
@@ -156,6 +171,7 @@ class CardControllerTest extends BaseMvcTest {
         String name = "cardName";
         String description = "cardDescription";
         String fileUrl = "fileUrl";
+        Double cardSequence = 1.0;
         String deadline = "2023.12.29 10:29:18";
         List<ChecklistGetRes> checklists = List.of(checklistGetRes);
         CardGetRes cardGetRes =
@@ -164,8 +180,11 @@ class CardControllerTest extends BaseMvcTest {
                         .name(name)
                         .description(description)
                         .fileUrl(fileUrl)
+                        .sequence(cardSequence)
                         .deadline(deadline)
                         .checklists(checklists)
+                        .workers(List.of(workerGetRes))
+                        .comments(List.of(commentGetRes))
                         .build();
         when(cardService.getCard(any(), any())).thenReturn(cardGetRes);
         this.mockMvc
@@ -195,7 +214,7 @@ class CardControllerTest extends BaseMvcTest {
                 .perform(
                         patch("/api/v1/cards/order")
                                 .contentType(APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(cardChangeSequenceRes))
+                                .content(objectMapper.writeValueAsString(cardChangeSequenceReq))
                                 .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());


### PR DESCRIPTION
## 개요
card 조회 시 담당자, 댓글 list도 같이 조회되도록 수정합니다.

## 작업사항
- CardGetRes에 workers, comments 추가
- api 테스트코드 수정
- restdocs 반영 확인

## 관련 이슈
- close #114 
