### PR TITLE
category sequence 재정렬 스케줄링 추가

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/repository/CategoryRepository.java
@@ -19,4 +19,8 @@ public interface CategoryRepository {
     Category findByCategoryId(Long categoryId);
 
     List<Category> findByTeamTeamIdOrderBySequenceAsc(Long teamId);
+
+    List<Category> findByOrderByTeamTeamIdAscSequenceAsc();
+
+    List<Category> saveAll(Iterable<Category> categories);
 }

--- a/src/main/java/com/vt/valuetogether/domain/category/service/CategorySchedulingService.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/CategorySchedulingService.java
@@ -1,0 +1,5 @@
+package com.vt.valuetogether.domain.category.service;
+
+public interface CategorySchedulingService {
+    void resetSequence();
+}

--- a/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategorySchedulingServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategorySchedulingServiceImpl.java
@@ -1,0 +1,47 @@
+package com.vt.valuetogether.domain.category.service.impl;
+
+import com.vt.valuetogether.domain.category.entity.Category;
+import com.vt.valuetogether.domain.category.repository.CategoryRepository;
+import com.vt.valuetogether.domain.category.service.CategorySchedulingService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@EnableScheduling
+@RequiredArgsConstructor
+public class CategorySchedulingServiceImpl implements CategorySchedulingService {
+    private final CategoryRepository categoryRepository;
+    private final double ADD_SEQUENCE = 1.0;
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void resetSequence() {
+        List<Category> categories = categoryRepository.findByOrderByTeamTeamIdAscSequenceAsc();
+        Long prevTeamId = categories.get(0).getTeam().getTeamId();
+        double sequence = 0.0;
+        List<Category> newCategories = new ArrayList<>();
+        for (Category category : categories) {
+            sequence = getNewSequence(sequence, prevTeamId, category.getTeam().getTeamId());
+            newCategories.add(
+                    Category.builder()
+                            .categoryId(category.getCategoryId())
+                            .name(category.getName())
+                            .sequence(sequence)
+                            .isDeleted(category.getIsDeleted())
+                            .team(category.getTeam())
+                            .build());
+            prevTeamId = category.getTeam().getTeamId();
+        }
+        categoryRepository.saveAll(newCategories);
+    }
+
+    private double getNewSequence(double sequence, Long prevTeamId, Long nowTeamId) {
+        if (!prevTeamId.equals(nowTeamId)) {
+            return ADD_SEQUENCE;
+        }
+        return sequence + ADD_SEQUENCE;
+    }
+}

--- a/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
@@ -102,4 +102,17 @@ class CategoryRepositoryTest implements CategoryTest {
         assertThat(categories.get(0)).isEqualTo(saveCategory1);
         assertThat(categories.get(1)).isEqualTo(saveCategory2);
     }
+
+    @Test
+    @DisplayName("teamId별 category list 조회 테스트")
+    void teamId_category_list_조회() {
+        // given
+
+        // when
+        List<Category> categories = categoryRepository.findByOrderByTeamTeamIdAscSequenceAsc();
+
+        // then
+        assertThat(categories.get(0)).isEqualTo(saveCategory1);
+        assertThat(categories.get(1)).isEqualTo(saveCategory2);
+    }
 }

--- a/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
@@ -115,4 +115,23 @@ class CategoryRepositoryTest implements CategoryTest {
         assertThat(categories.get(0)).isEqualTo(saveCategory1);
         assertThat(categories.get(1)).isEqualTo(saveCategory2);
     }
+
+    @Test
+    @DisplayName("categories 저장 테스트")
+    void categories_저장() {
+        // given
+        List<Category> categories = List.of(TEST_CATEGORY, TEST_ANOTHER_CATEGORY);
+
+        // when
+        List<Category> saveCategories = categoryRepository.saveAll(categories);
+
+        // then
+        assertThat(saveCategories.get(0).getName()).isEqualTo(categories.get(0).getName());
+        assertThat(saveCategories.get(0).getSequence()).isEqualTo(categories.get(0).getSequence());
+        assertThat(saveCategories.get(0).getIsDeleted()).isEqualTo(categories.get(0).getIsDeleted());
+
+        assertThat(saveCategories.get(1).getName()).isEqualTo(categories.get(1).getName());
+        assertThat(saveCategories.get(1).getSequence()).isEqualTo(categories.get(1).getSequence());
+        assertThat(saveCategories.get(1).getIsDeleted()).isEqualTo(categories.get(1).getIsDeleted());
+    }
 }

--- a/src/test/java/com/vt/valuetogether/test/CategoryTest.java
+++ b/src/test/java/com/vt/valuetogether/test/CategoryTest.java
@@ -22,4 +22,13 @@ public interface CategoryTest extends TeamTest {
                     .isDeleted(TEST_CATEGORY_IS_DELETED)
                     .team(TEST_TEAM)
                     .build();
+
+    Category TEST_ANOTHER_CATEGORY =
+            Category.builder()
+                    .categoryId(TEST_ANOTHER_CATEGORY_ID)
+                    .name(TEST_ANOTHER_CATEGORY_NAME)
+                    .sequence(TEST_ANOTHER_CATEGORY_SEQUENCE)
+                    .isDeleted(TEST_ANOTHER_CATEGORY_IS_DELETED)
+                    .team(TEST_TEAM)
+                    .build();
 }


### PR DESCRIPTION
## 개요
team별로 category sequence를 재정렬하는 스케줄러를 추가합니다.

## 작업사항
- reset category serqnence 스케줄링 추가
- 테스트코드 추가

## 관련 이슈
- close #120 
