### PR TITLE
username 중복 검사 api 오류 수정

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/user/controller/UserController.java
+++ b/src/main/java/com/vt/valuetogether/domain/user/controller/UserController.java
@@ -69,7 +69,7 @@ public class UserController {
             @RequestPart(name = "data") UserUpdateProfileReq req,
             @RequestPart(name = "image", required = false) MultipartFile multipartfile,
             @AuthenticationPrincipal UserDetails userDetails) {
-        req.setUsername(userDetails.getUsername());
+        req.setPreUsername(userDetails.getUsername());
         return RestResponse.success(userService.updateProfile(req, multipartfile));
     }
 


### PR DESCRIPTION
## 개요
username 중복 검사 api의 오류를 수정합니다.

## 작업사항
- 사용자의 이름을 username이 아닌 preUsername에 저장

## 관련 이슈
- close #132 
