### PR TITLE
deleted 상태가 아닌 카테고리만 조회

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/category/dto/response/CategoryGetRes.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/dto/response/CategoryGetRes.java
@@ -13,20 +13,14 @@ public class CategoryGetRes {
     private Long categoryId;
     private String name;
     private Double sequence;
-    private Boolean isDeleted;
     private List<CardInnerCategoryRes> cards;
 
     @Builder
     private CategoryGetRes(
-            Long categoryId,
-            String name,
-            Double sequence,
-            Boolean isDeleted,
-            List<CardInnerCategoryRes> cards) {
+            Long categoryId, String name, Double sequence, List<CardInnerCategoryRes> cards) {
         this.categoryId = categoryId;
         this.name = name;
         this.sequence = sequence;
-        this.isDeleted = isDeleted;
         this.cards = cards;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/repository/CategoryRepository.java
@@ -19,7 +19,7 @@ public interface CategoryRepository {
 
     Category findByCategoryId(Long categoryId);
 
-    List<Category> findByTeamTeamIdOrderBySequenceAsc(Long teamId);
+    List<Category> findByTeamTeamIdAndIsDeletedOrderBySequenceAsc(Long teamId, Boolean isDeleted);
 
     List<Category> findByOrderByTeamTeamIdAscSequenceAsc();
 

--- a/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImpl.java
@@ -141,7 +141,7 @@ public class CategoryServiceImpl implements CategoryService {
         TeamRoleValidator.checkIsTeamMember(team.getTeamRoleList(), user);
         List<CategoryGetRes> categoryGetReses =
                 CategoryServiceMapper.INSTANCE.toCategoryGetResList(
-                        categoryRepository.findByTeamTeamIdOrderBySequenceAsc(teamId));
+                        categoryRepository.findByTeamTeamIdAndIsDeletedOrderBySequenceAsc(teamId, FALSE));
         return CategoryGetResList.builder()
                 .categories(categoryGetReses)
                 .total(categoryGetReses.size())

--- a/src/test/java/com/vt/valuetogether/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/controller/CategoryControllerTest.java
@@ -1,6 +1,5 @@
 package com.vt.valuetogether.domain.category.controller;
 
-import static java.lang.Boolean.FALSE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -100,13 +99,11 @@ class CategoryControllerTest extends BaseMvcTest {
         Long categoryId = 1L;
         String categoryName = "categoryName";
         Double categorySequence = 1.0;
-        Boolean isDeleted = FALSE;
         CategoryGetRes categoryGetRes =
                 CategoryGetRes.builder()
                         .categoryId(categoryId)
                         .name(categoryName)
                         .sequence(categorySequence)
-                        .isDeleted(isDeleted)
                         .cards(List.of(cardInnerCategoryRes))
                         .build();
         int total = 1;

--- a/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.vt.valuetogether.domain.category.repository;
 
+import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -101,7 +102,8 @@ class CategoryRepositoryTest implements CategoryTest {
 
         // when
         List<Category> categories =
-                categoryRepository.findByTeamTeamIdOrderBySequenceAsc(saveTeam.getTeamId());
+                categoryRepository.findByTeamTeamIdAndIsDeletedOrderBySequenceAsc(
+                        saveTeam.getTeamId(), FALSE);
 
         // then
         assertThat(categories.get(0)).isEqualTo(saveCategory1);

--- a/src/test/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/service/impl/CategoryServiceImplTest.java
@@ -112,7 +112,8 @@ class CategoryServiceImplTest implements CategoryTest, UserTest, TeamRoleTest {
         // given
         when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
         when(teamRepository.findByTeamId(any())).thenReturn(team);
-        when(categoryRepository.findByTeamTeamIdOrderBySequenceAsc(any())).thenReturn(categories);
+        when(categoryRepository.findByTeamTeamIdAndIsDeletedOrderBySequenceAsc(any(), any()))
+                .thenReturn(categories);
 
         // when
         CategoryGetResList categoryGetResList =


### PR DESCRIPTION
## 개요
deleted 상태가 아닌 카테고리만 조회되도록 수정합니다.

## 작업사항
- repository 메소드 변경
- 테스트코드 변경

## 관련 이슈
- close #129 
