### PR TITLE
카테고리 재정렬 시 전체조회 로직 수정

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/repository/CategoryRepository.java
@@ -21,7 +21,7 @@ public interface CategoryRepository {
 
     List<Category> findByTeamTeamIdAndIsDeletedOrderBySequenceAsc(Long teamId, Boolean isDeleted);
 
-    List<Category> findByOrderByTeamTeamIdAscSequenceAsc();
+    List<Category> findByIsDeletedOrderByTeamTeamIdAscSequenceAsc(Boolean isDeleted);
 
     List<Category> saveAll(Iterable<Category> categories);
 

--- a/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategorySchedulingServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/impl/CategorySchedulingServiceImpl.java
@@ -1,5 +1,8 @@
 package com.vt.valuetogether.domain.category.service.impl;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 import com.vt.valuetogether.domain.category.entity.Category;
 import com.vt.valuetogether.domain.category.repository.CategoryRepository;
 import com.vt.valuetogether.domain.category.service.CategorySchedulingService;
@@ -26,7 +29,8 @@ public class CategorySchedulingServiceImpl implements CategorySchedulingService 
     @Scheduled(cron = "0 30 0 * * ?")
     @Transactional
     public void resetSequence() {
-        List<Category> categories = categoryRepository.findByOrderByTeamTeamIdAscSequenceAsc();
+        List<Category> categories =
+                categoryRepository.findByIsDeletedOrderByTeamTeamIdAscSequenceAsc(FALSE);
         if (CollectionUtils.isEmpty(categories)) {
             return;
         }
@@ -62,6 +66,6 @@ public class CategorySchedulingServiceImpl implements CategorySchedulingService 
         ZonedDateTime dateTime = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("Asia/Seoul"));
         LocalDateTime localDateTime =
                 dateTime.toLocalDate().minusDays(CATEGORY_RETENTION_PERIOD).atStartOfDay();
-        categoryRepository.deleteByIsDeletedAndModifiedAtBefore(true, localDateTime);
+        categoryRepository.deleteByIsDeletedAndModifiedAtBefore(TRUE, localDateTime);
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/category/repository/CategoryRepositoryTest.java
@@ -114,9 +114,11 @@ class CategoryRepositoryTest implements CategoryTest {
     @DisplayName("teamId별 category list 조회 테스트")
     void teamId_category_list_조회() {
         // given
+        Boolean isDeleted = FALSE;
 
         // when
-        List<Category> categories = categoryRepository.findByOrderByTeamTeamIdAscSequenceAsc();
+        List<Category> categories =
+                categoryRepository.findByIsDeletedOrderByTeamTeamIdAscSequenceAsc(isDeleted);
 
         // then
         assertThat(categories.get(0)).isEqualTo(saveCategory1);


### PR DESCRIPTION
## 개요
카테고리 전체 조회 시 `isDeleted=false`인 카테고리들만 조회하도록 수정합니다.

## 작업사항
- repository 메소드 수정
- 테스트코드 수정

## 관련 이슈
- close #137 
