### PR TITLE
email link에 yml 변수 주입

### DIFF
--- a/src/main/java/com/vt/valuetogether/infra/mail/MailUtil.java
+++ b/src/main/java/com/vt/valuetogether/infra/mail/MailUtil.java
@@ -29,9 +29,12 @@ public class MailUtil {
     private final EmailAuthService emailService;
     private final InviteCodeService inviteCodeService;
 
-    private static final String EMAIL_LINK = "http://localhost:8080/api/v1/users/signup/email/check?";
-    private static final String INVITE_EMAIL_LINK =
-            "http://localhost:8080/api/v1/teams/members/email?";
+    @Value("${spring.mail.url.auth}")
+    private String authEmailLink;
+
+    @Value("${spring.mail.url.invite}")
+    private String inviteEmailLink;
+
     private static final String PATH_AND = "&";
     private static final String PATH_KEY_EMAIL = "email=";
     private static final String PATH_KEY_CODE = "authCode=";
@@ -103,7 +106,7 @@ public class MailUtil {
         message.addRecipients(RecipientType.TO, to);
         message.setSubject(subject, StandardCharsets.UTF_8.name());
         message.setContent(
-                EMAIL_LINK + PATH_KEY_EMAIL + to + PATH_AND + PATH_KEY_CODE + code,
+                authEmailLink + PATH_KEY_EMAIL + to + PATH_AND + PATH_KEY_CODE + code,
                 ContentType.TEXT_HTML.getMimeType());
 
         return message;
@@ -117,7 +120,7 @@ public class MailUtil {
         message.addRecipients(RecipientType.TO, to);
         message.setSubject(subject, StandardCharsets.UTF_8.name());
         message.setContent(
-                INVITE_EMAIL_LINK + PATH_KEY_EMAIL + to + PATH_AND + PATH_KEY_CODE + code,
+                inviteEmailLink + PATH_KEY_EMAIL + to + PATH_AND + PATH_KEY_CODE + code,
                 ContentType.TEXT_HTML.getMimeType());
 
         return message;


### PR DESCRIPTION
## 개요
email link에 yml 변수를 주입합니다.

## 작업사항
- MailUtil에서 이메일 인증, 멤버 초대용 email link에 yml 변수 주입

## 관련 이슈
- close #143 
