### PR TITLE
Worker, TemRole entity 연관관계 수정

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/card/service/CardServiceMapper.java
+++ b/src/main/java/com/vt/valuetogether/domain/card/service/CardServiceMapper.java
@@ -31,8 +31,8 @@ public interface CardServiceMapper {
     @Mapping(source = "user.username", target = "username")
     CommentGetRes toCommentGetRes(Comment comment);
 
-    @Mapping(source = "user.profileImageUrl", target = "profileImageUrl")
-    @Mapping(source = "user.username", target = "username")
+    @Mapping(source = "teamRole.user.profileImageUrl", target = "profileImageUrl")
+    @Mapping(source = "teamRole.user.username", target = "username")
     WorkerGetRes toWorkerGetRes(Worker worker);
 
     @Mapping(source = "deadline", target = "deadline")

--- a/src/main/java/com/vt/valuetogether/domain/category/service/CategoryServiceMapper.java
+++ b/src/main/java/com/vt/valuetogether/domain/category/service/CategoryServiceMapper.java
@@ -29,8 +29,8 @@ public interface CategoryServiceMapper {
         return zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }
 
-    @Mapping(source = "user.profileImageUrl", target = "profileImageUrl")
-    @Mapping(source = "user.username", target = "username")
+    @Mapping(source = "teamRole.user.profileImageUrl", target = "profileImageUrl")
+    @Mapping(source = "teamRole.user.username", target = "username")
     WorkerGetRes toWorkerGetRes(Worker worker);
 
     @Mapping(source = "deadline", target = "deadline")

--- a/src/main/java/com/vt/valuetogether/domain/team/entity/TeamRole.java
+++ b/src/main/java/com/vt/valuetogether/domain/team/entity/TeamRole.java
@@ -42,14 +42,11 @@ public class TeamRole {
     @Enumerated(value = EnumType.STRING)
     private Role role;
 
-    private boolean isDeleted;
-
     @Builder
-    private TeamRole(Long teamRoleId, User user, Team team, Role role, boolean isDeleted) {
+    private TeamRole(Long teamRoleId, User user, Team team, Role role) {
         this.teamRoleId = teamRoleId;
         this.user = user;
         this.team = team;
         this.role = role;
-        this.isDeleted = isDeleted;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/team/repository/TeamRoleRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/team/repository/TeamRoleRepository.java
@@ -12,4 +12,8 @@ public interface TeamRoleRepository {
     List<TeamRole> saveAll(Iterable<TeamRole> teamRoleList);
 
     List<TeamRole> findByTeam_TeamId(Long teamId);
+
+    TeamRole findByUserUsernameAndTeamTeamId(String username, Long teamId);
+
+    void delete(TeamRole teamRole);
 }

--- a/src/main/java/com/vt/valuetogether/domain/worker/controller/WorkerController.java
+++ b/src/main/java/com/vt/valuetogether/domain/worker/controller/WorkerController.java
@@ -23,7 +23,9 @@ public class WorkerController {
     private final WorkerService workerService;
 
     @PostMapping
-    public RestResponse<WorkerAddRes> addWorker(@RequestBody WorkerAddReq req) {
+    public RestResponse<WorkerAddRes> addWorker(
+            @RequestBody WorkerAddReq req, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        req.setUsername(userDetails.getUsername());
         return RestResponse.success(workerService.addWorker(req));
     }
 

--- a/src/main/java/com/vt/valuetogether/domain/worker/dto/request/WorkerAddReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/worker/dto/request/WorkerAddReq.java
@@ -1,6 +1,5 @@
 package com.vt.valuetogether.domain.worker.dto.request;
 
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,11 +13,11 @@ public class WorkerAddReq {
 
     private Long cardId;
     private String username;
-    private List<Long> userIds;
+    private String addUsername;
 
     @Builder
-    private WorkerAddReq(Long cardId, List<Long> userIds) {
+    private WorkerAddReq(Long cardId, String addUsername) {
         this.cardId = cardId;
-        this.userIds = userIds;
+        this.addUsername = addUsername;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/worker/dto/request/WorkerDeleteReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/worker/dto/request/WorkerDeleteReq.java
@@ -13,9 +13,11 @@ public class WorkerDeleteReq {
 
     private Long cardId;
     private String username;
+    private String deleteUsername;
 
     @Builder
-    private WorkerDeleteReq(Long cardId) {
+    private WorkerDeleteReq(Long cardId, String deleteUsername) {
         this.cardId = cardId;
+        this.deleteUsername = deleteUsername;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/worker/entity/Worker.java
+++ b/src/main/java/com/vt/valuetogether/domain/worker/entity/Worker.java
@@ -1,7 +1,7 @@
 package com.vt.valuetogether.domain.worker.entity;
 
 import com.vt.valuetogether.domain.card.entity.Card;
-import com.vt.valuetogether.domain.user.entity.User;
+import com.vt.valuetogether.domain.team.entity.TeamRole;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
@@ -25,9 +25,9 @@ public class Worker {
 
     @Id
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId")
+    @JoinColumn(name = "teamRoleId")
     @OnDelete(action = OnDeleteAction.CASCADE)
-    private User user;
+    private TeamRole teamRole;
 
     @Id
     @ManyToOne(fetch = FetchType.LAZY)
@@ -35,8 +35,8 @@ public class Worker {
     private Card card;
 
     @Builder
-    private Worker(User user, Card card) {
-        this.user = user;
+    private Worker(TeamRole teamRole, Card card) {
+        this.teamRole = teamRole;
         this.card = card;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/worker/entity/WorkerPK.java
+++ b/src/main/java/com/vt/valuetogether/domain/worker/entity/WorkerPK.java
@@ -12,6 +12,6 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 public class WorkerPK implements Serializable {
 
-    private Long user;
+    private Long teamRole;
     private Long card;
 }

--- a/src/main/java/com/vt/valuetogether/domain/worker/repository/WorkerRepository.java
+++ b/src/main/java/com/vt/valuetogether/domain/worker/repository/WorkerRepository.java
@@ -1,7 +1,7 @@
 package com.vt.valuetogether.domain.worker.repository;
 
 import com.vt.valuetogether.domain.card.entity.Card;
-import com.vt.valuetogether.domain.user.entity.User;
+import com.vt.valuetogether.domain.team.entity.TeamRole;
 import com.vt.valuetogether.domain.worker.entity.Worker;
 import com.vt.valuetogether.domain.worker.entity.WorkerPK;
 import org.springframework.data.repository.RepositoryDefinition;
@@ -11,7 +11,7 @@ public interface WorkerRepository {
 
     Worker save(Worker worker);
 
-    Worker findByUserAndCard(User user, Card card);
+    Worker findByTeamRoleAndCard(TeamRole teamRole, Card card);
 
     void delete(Worker worker);
 }

--- a/src/main/java/com/vt/valuetogether/domain/worker/service/impl/WorkerServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/worker/service/impl/WorkerServiceImpl.java
@@ -2,6 +2,8 @@ package com.vt.valuetogether.domain.worker.service.impl;
 
 import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.domain.card.repository.CardRepository;
+import com.vt.valuetogether.domain.team.entity.TeamRole;
+import com.vt.valuetogether.domain.team.repository.TeamRoleRepository;
 import com.vt.valuetogether.domain.user.entity.User;
 import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.domain.worker.dto.request.WorkerAddReq;
@@ -13,6 +15,7 @@ import com.vt.valuetogether.domain.worker.repository.WorkerRepository;
 import com.vt.valuetogether.domain.worker.service.WorkerService;
 import com.vt.valuetogether.domain.worker.service.WorkerServiceMapper;
 import com.vt.valuetogether.global.validator.CardValidator;
+import com.vt.valuetogether.global.validator.TeamRoleValidator;
 import com.vt.valuetogether.global.validator.UserValidator;
 import com.vt.valuetogether.global.validator.WorkerValidator;
 import lombok.RequiredArgsConstructor;
@@ -26,20 +29,24 @@ public class WorkerServiceImpl implements WorkerService {
     private final UserRepository userRepository;
     private final CardRepository cardRepository;
     private final WorkerRepository workerRepository;
+    private final TeamRoleRepository teamRoleRepository;
 
     @Transactional
     @Override
     public WorkerAddRes addWorker(WorkerAddReq req) {
-        User user = findUser(req.getUsername());
-        Card card = findCard(req.getCardId());
+        Card card = findCard(req.getCardId(), req.getUsername());
+        TeamRole teamRole =
+                findTeamRole(req.getAddUsername(), card.getCategory().getTeam().getTeamId());
 
         return WorkerServiceMapper.INSTANCE.toWorkerAddRes(
-                workerRepository.save(Worker.builder().user(user).card(card).build()));
+                workerRepository.save(Worker.builder().teamRole(teamRole).card(card).build()));
     }
 
-    private Card findCard(Long cardId) {
+    private Card findCard(Long cardId, String username) {
+        User user = findUser(username);
         Card card = cardRepository.findByCardId(cardId);
         CardValidator.validate(card);
+        TeamRoleValidator.checkIsTeamMember(card.getCategory().getTeam().getTeamRoleList(), user);
         return card;
     }
 
@@ -47,6 +54,12 @@ public class WorkerServiceImpl implements WorkerService {
         User user = userRepository.findByUsername(username);
         UserValidator.validate(user);
         return user;
+    }
+
+    private TeamRole findTeamRole(String username, Long teamId) {
+        TeamRole teamRole = teamRoleRepository.findByUserUsernameAndTeamTeamId(username, teamId);
+        TeamRoleValidator.validate(teamRole);
+        return teamRole;
     }
 
     @Transactional
@@ -57,10 +70,11 @@ public class WorkerServiceImpl implements WorkerService {
     }
 
     private Worker findWorker(WorkerDeleteReq req) {
-        User user = findUser(req.getUsername());
-        Card card = findCard(req.getCardId());
+        Card card = findCard(req.getCardId(), req.getUsername());
+        TeamRole teamRole =
+                findTeamRole(req.getDeleteUsername(), card.getCategory().getTeam().getTeamId());
 
-        Worker worker = workerRepository.findByUserAndCard(user, card);
+        Worker worker = workerRepository.findByTeamRoleAndCard(teamRole, card);
         WorkerValidator.validator(worker);
         return worker;
     }

--- a/src/main/java/com/vt/valuetogether/global/meta/ResultCode.java
+++ b/src/main/java/com/vt/valuetogether/global/meta/ResultCode.java
@@ -41,6 +41,7 @@ public enum ResultCode {
     NOT_FOUND_TEAM_ROLE(HttpStatus.NOT_FOUND, 3004, "teamRole 이 존재하지 않습니다."),
     FORBIDDEN_TEAM_ROLE(HttpStatus.FORBIDDEN, 3005, "팀의 멤버만 해당 작업을 수행할 수 있습니다."),
     NOT_FOUND_TEAM_MEMBER(HttpStatus.NOT_FOUND, 3006, "팀의 멤버가 아닙니다."),
+    NOT_AUTHORITY_TEAM_ROLE(HttpStatus.UNAUTHORIZED, 3007, "멤버 삭제 권한이 없습니다."),
 
     // 카테고리 4000번대
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, 4000, "존재하지 않는 카테고리 입니다."),

--- a/src/main/java/com/vt/valuetogether/global/validator/TeamRoleValidator.java
+++ b/src/main/java/com/vt/valuetogether/global/validator/TeamRoleValidator.java
@@ -1,6 +1,8 @@
 package com.vt.valuetogether.global.validator;
 
+import static com.vt.valuetogether.domain.team.entity.Role.LEADER;
 import static com.vt.valuetogether.global.meta.ResultCode.FORBIDDEN_TEAM_ROLE;
+import static com.vt.valuetogether.global.meta.ResultCode.NOT_AUTHORITY_TEAM_ROLE;
 import static com.vt.valuetogether.global.meta.ResultCode.NOT_FOUND_TEAM_ROLE;
 
 import com.vt.valuetogether.domain.team.entity.TeamRole;
@@ -27,13 +29,36 @@ public class TeamRoleValidator {
         }
     }
 
+    public static void validate(TeamRole teamRole) {
+        if (isNullTeamRole(teamRole)) {
+            throw new GlobalException(NOT_FOUND_TEAM_ROLE);
+        }
+    }
+
+    public static void validate(TeamRole teamRole, String deleteUsername) {
+        if (!isLeader(teamRole) && !isMe(teamRole.getUser().getUsername(), deleteUsername)) {
+            throw new GlobalException(NOT_AUTHORITY_TEAM_ROLE);
+        }
+    }
+
+    private static boolean isLeader(TeamRole teamRole) {
+        return LEADER.equals(teamRole.getRole());
+    }
+
+    private static boolean isMe(String username, String deleteUsername) {
+        return username.equals(deleteUsername);
+    }
+
+    private static boolean isNullTeamRole(TeamRole teamRole) {
+        return teamRole == null;
+    }
+
     private static boolean checkIsNull(List<TeamRole> teamRoleList) {
         return CollectionUtils.isEmpty(teamRoleList);
     }
 
     private static boolean teamRoleListContainsUser(List<TeamRole> teamRoleList, User user) {
         return teamRoleList.stream()
-                .filter(teamRole -> !teamRole.isDeleted())
                 .anyMatch(teamRole -> teamRole.getUser().getUserId().equals(user.getUserId()));
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/team/service/impl/TeamServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/team/service/impl/TeamServiceImplTest.java
@@ -1,7 +1,6 @@
 package com.vt.valuetogether.domain.team.service.impl;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -116,6 +115,5 @@ class TeamServiceImplTest implements TeamTest {
         verify(teamRepository, times(1)).findByTeamId(anyLong());
         verify(teamRoleRepository, times(1)).findByTeam_TeamId(anyLong());
         verify(teamRepository, times(1)).save(any(Team.class));
-        verify(teamRoleRepository, times(1)).saveAll(anyList());
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/worker/controller/WorkerControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/worker/controller/WorkerControllerTest.java
@@ -14,7 +14,6 @@ import com.vt.valuetogether.domain.worker.dto.response.WorkerAddRes;
 import com.vt.valuetogether.domain.worker.dto.response.WorkerDeleteRes;
 import com.vt.valuetogether.domain.worker.service.WorkerService;
 import com.vt.valuetogether.test.WorkerTest;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -31,10 +30,7 @@ class WorkerControllerTest extends BaseMvcTest implements WorkerTest {
     void worker_저장() throws Exception {
         // given
         WorkerAddReq workerAddReq =
-                WorkerAddReq.builder()
-                        .cardId(TEST_CARD_ID)
-                        .userIds(List.of(TEST_USER_ID, TEST_ANOTHER_USER_ID))
-                        .build();
+                WorkerAddReq.builder().cardId(TEST_CARD_ID).addUsername(TEST_ANOTHER_USER_NAME).build();
         WorkerAddRes workerAddRes = new WorkerAddRes();
 
         // when - then
@@ -43,7 +39,8 @@ class WorkerControllerTest extends BaseMvcTest implements WorkerTest {
                 .perform(
                         post("/api/v1/workers")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(workerAddReq)))
+                                .content(objectMapper.writeValueAsString(workerAddReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/worker/repository/WorkerRepositoryTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/worker/repository/WorkerRepositoryTest.java
@@ -5,8 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.domain.card.repository.CardRepository;
 import com.vt.valuetogether.domain.category.repository.CategoryRepository;
+import com.vt.valuetogether.domain.team.entity.TeamRole;
 import com.vt.valuetogether.domain.team.repository.TeamRepository;
-import com.vt.valuetogether.domain.user.entity.User;
+import com.vt.valuetogether.domain.team.repository.TeamRoleRepository;
 import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.domain.worker.entity.Worker;
 import com.vt.valuetogether.test.WorkerTest;
@@ -27,53 +28,59 @@ class WorkerRepositoryTest implements WorkerTest {
     @Autowired private WorkerRepository workerRepository;
     @Autowired private CategoryRepository categoryRepository;
     @Autowired private TeamRepository teamRepository;
+    @Autowired private TeamRoleRepository teamRoleRepository;
 
     @Test
     @DisplayName("worker 저장 테스트")
     void worker_저장() {
         // given
-        User savedUser = userRepository.save(User.builder().build());
+        userRepository.save(TEST_USER);
         teamRepository.save(TEST_TEAM);
+        TeamRole savedTeamRole = teamRoleRepository.save(TEST_TEAM_ROLE);
         categoryRepository.save(TEST_CATEGORY);
         cardRepository.save(TEST_CARD);
 
         // when
-        Worker worker = workerRepository.save(Worker.builder().user(savedUser).card(TEST_CARD).build());
+        Worker worker =
+                workerRepository.save(Worker.builder().teamRole(savedTeamRole).card(TEST_CARD).build());
 
         // then
-        assertThat(worker.getUser().getUserId()).isEqualTo(savedUser.getUserId());
+        assertThat(worker.getTeamRole().getTeamRoleId()).isEqualTo(savedTeamRole.getTeamRoleId());
     }
 
     @Test
     @DisplayName("id로 worker 조회 테스트")
     void id_worker_조회() {
         // given
-        User savedUser = userRepository.save(TEST_USER);
+        userRepository.save(TEST_USER);
         teamRepository.save(TEST_TEAM);
+        TeamRole savedTeamRole = teamRoleRepository.save(TEST_TEAM_ROLE);
         categoryRepository.save(TEST_CATEGORY);
         Card savedCard = cardRepository.save(TEST_CARD);
         Worker savedWorker = workerRepository.save(TEST_WORKER);
 
         // when
-        Worker worker = workerRepository.findByUserAndCard(savedUser, savedCard);
+        Worker worker = workerRepository.findByTeamRoleAndCard(savedTeamRole, savedCard);
 
         // then
-        assertThat(worker.getUser().getUserId()).isEqualTo(savedWorker.getUser().getUserId());
+        assertThat(worker.getTeamRole().getTeamRoleId())
+                .isEqualTo(savedWorker.getTeamRole().getTeamRoleId());
     }
 
     @Test
     @DisplayName("worker 삭제 테스트")
     void worker_삭제() {
         // given
-        User user = userRepository.save(User.builder().build());
+        userRepository.save(TEST_USER);
         teamRepository.save(TEST_TEAM);
+        TeamRole teamRole = teamRoleRepository.save(TEST_TEAM_ROLE);
         categoryRepository.save(TEST_CATEGORY);
         Card card = cardRepository.save(Card.builder().build());
-        Worker worker = workerRepository.save(Worker.builder().user(user).card(card).build());
+        Worker worker = workerRepository.save(Worker.builder().teamRole(teamRole).card(card).build());
 
         // when
         workerRepository.delete(worker);
-        Worker findWorker = workerRepository.findByUserAndCard(user, card);
+        Worker findWorker = workerRepository.findByTeamRoleAndCard(teamRole, card);
 
         // then
         assertThat(findWorker).isNull();

--- a/src/test/java/com/vt/valuetogether/domain/worker/service/WorkerServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/worker/service/WorkerServiceImplTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.verify;
 
 import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.domain.card.repository.CardRepository;
-import com.vt.valuetogether.domain.user.entity.User;
+import com.vt.valuetogether.domain.category.entity.Category;
+import com.vt.valuetogether.domain.team.entity.Team;
+import com.vt.valuetogether.domain.team.repository.TeamRoleRepository;
 import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.domain.worker.dto.request.WorkerAddReq;
 import com.vt.valuetogether.domain.worker.dto.request.WorkerDeleteReq;
@@ -16,6 +18,7 @@ import com.vt.valuetogether.domain.worker.repository.WorkerRepository;
 import com.vt.valuetogether.domain.worker.service.impl.WorkerServiceImpl;
 import com.vt.valuetogether.test.WorkerTest;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,20 +32,54 @@ class WorkerServiceImplTest implements WorkerTest {
     @Mock UserRepository userRepository;
     @Mock CardRepository cardRepository;
     @Mock WorkerRepository workerRepository;
+    @Mock TeamRoleRepository teamRoleRepository;
     @InjectMocks private WorkerServiceImpl workerService;
+    private Card card;
+    private Category category;
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team =
+                Team.builder()
+                        .teamId(TEST_TEAM_ID)
+                        .teamName(TEST_TEAM_NAME)
+                        .teamDescription(TEST_TEAM_DESCRIPTION)
+                        .backgroundColor(TEST_BACKGROUND_COLOR)
+                        .isDeleted(TEST_TEAM_IS_DELETED)
+                        .teamRoleList(List.of(TEST_TEAM_ROLE))
+                        .build();
+        category =
+                Category.builder()
+                        .categoryId(TEST_CATEGORY_ID)
+                        .name(TEST_CATEGORY_NAME)
+                        .sequence(TEST_CATEGORY_SEQUENCE)
+                        .isDeleted(TEST_CATEGORY_IS_DELETED)
+                        .team(team)
+                        .build();
+        card =
+                Card.builder()
+                        .cardId(TEST_CARD_ID)
+                        .name(TEST_NAME)
+                        .description(TEST_DESCRIPTION)
+                        .fileUrl(TEST_FILE_URL)
+                        .sequence(TEST_SEQUENCE)
+                        .deadline(TEST_DEADLINE)
+                        .category(category)
+                        .build();
+    }
 
     @Test
     @DisplayName("worker 저장 테스트")
     void worker_저장() {
         // given
         WorkerAddReq workerAddReq =
-                WorkerAddReq.builder()
-                        .cardId(TEST_CARD_ID)
-                        .userIds(List.of(TEST_USER_ID, TEST_ANOTHER_USER_ID))
-                        .build();
+                WorkerAddReq.builder().cardId(TEST_CARD_ID).addUsername(TEST_ANOTHER_NAME).build();
 
-        given(cardRepository.findByCardId(anyLong())).willReturn(TEST_CARD);
+        given(cardRepository.findByCardId(anyLong())).willReturn(card);
         given(userRepository.findByUsername(any())).willReturn(TEST_USER);
+        given(teamRoleRepository.findByUserUsernameAndTeamTeamId(any(), any()))
+                .willReturn(TEST_TEAM_ROLE);
         given(workerRepository.save(any(Worker.class))).willReturn(TEST_WORKER);
 
         // when
@@ -51,6 +88,7 @@ class WorkerServiceImplTest implements WorkerTest {
         // then
         verify(cardRepository).findByCardId(any());
         verify(userRepository).findByUsername(any());
+        verify(teamRoleRepository).findByUserUsernameAndTeamTeamId(any(), any());
         verify(workerRepository).save(any(Worker.class));
     }
 
@@ -60,16 +98,20 @@ class WorkerServiceImplTest implements WorkerTest {
         // given
         WorkerDeleteReq workerDeleteReq = WorkerDeleteReq.builder().cardId(TEST_CARD_ID).build();
 
-        given(cardRepository.findByCardId(anyLong())).willReturn(TEST_CARD);
+        given(cardRepository.findByCardId(anyLong())).willReturn(card);
         given(userRepository.findByUsername(any())).willReturn(TEST_USER);
-        given(workerRepository.findByUserAndCard(any(User.class), any(Card.class)))
-                .willReturn(TEST_WORKER);
+        given(teamRoleRepository.findByUserUsernameAndTeamTeamId(any(), any()))
+                .willReturn(TEST_TEAM_ROLE);
+        given(workerRepository.findByTeamRoleAndCard(any(), any())).willReturn(TEST_WORKER);
 
         // when
         workerService.deleteWorker(workerDeleteReq);
 
         // then
-        verify(workerRepository).findByUserAndCard(any(User.class), any(Card.class));
+        verify(cardRepository).findByCardId(anyLong());
+        verify(userRepository).findByUsername(any());
+        verify(teamRoleRepository).findByUserUsernameAndTeamTeamId(any(), any());
+        verify(workerRepository).findByTeamRoleAndCard(any(), any());
         verify(workerRepository).delete(any(Worker.class));
     }
 }

--- a/src/test/java/com/vt/valuetogether/test/TeamRoleTest.java
+++ b/src/test/java/com/vt/valuetogether/test/TeamRoleTest.java
@@ -6,7 +6,6 @@ import com.vt.valuetogether.domain.team.entity.TeamRole;
 public interface TeamRoleTest extends TeamTest, UserTest {
     Long TEST_TEAM_ROLE_ID = 1L;
     Role TEST_TEAM_ROLE_ROLE = Role.LEADER;
-    boolean TEST_TEAM_ROLE_IS_DELETED = false;
 
     TeamRole TEST_TEAM_ROLE =
             TeamRole.builder()
@@ -14,6 +13,5 @@ public interface TeamRoleTest extends TeamTest, UserTest {
                     .user(TEST_USER)
                     .team(TEST_TEAM)
                     .role(TEST_TEAM_ROLE_ROLE)
-                    .isDeleted(TEST_TEAM_ROLE_IS_DELETED)
                     .build();
 }

--- a/src/test/java/com/vt/valuetogether/test/WorkerTest.java
+++ b/src/test/java/com/vt/valuetogether/test/WorkerTest.java
@@ -2,7 +2,7 @@ package com.vt.valuetogether.test;
 
 import com.vt.valuetogether.domain.worker.entity.Worker;
 
-public interface WorkerTest extends UserTest, CardTest {
+public interface WorkerTest extends TeamRoleTest, CardTest {
 
-    Worker TEST_WORKER = Worker.builder().user(TEST_USER).card(TEST_CARD).build();
+    Worker TEST_WORKER = Worker.builder().teamRole(TEST_TEAM_ROLE).card(TEST_CARD).build();
 }


### PR DESCRIPTION
## 개요
Worker, User의 연관관계를 Worker, TeamRole의 연관관계로 수정합니다.

## 작업사항
- worker, teamrole 연관관계 수정
- teamrole에 isDeleted 제거
- 관련된 일부 로직 수정
- 관련된 일부 테스트코드 수정

## 관련 이슈
- #153 
