### PR TITLE
체크리스트 api 요청 시 팀의 멤버인지 확인 로직 추가

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/checklist/controller/ChecklistController.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/controller/ChecklistController.java
@@ -42,7 +42,9 @@ public class ChecklistController {
 
     @DeleteMapping
     public RestResponse<ChecklistDeleteRes> deleteChecklist(
-            @RequestBody ChecklistDeleteReq checklistDeleteReq) {
+            @RequestBody ChecklistDeleteReq checklistDeleteReq,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        checklistDeleteReq.setUsername(userDetails.getUsername());
         return RestResponse.success(checklistService.deleteChecklist(checklistDeleteReq));
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/checklist/controller/ChecklistController.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/controller/ChecklistController.java
@@ -34,7 +34,9 @@ public class ChecklistController {
 
     @PatchMapping
     public RestResponse<ChecklistUpdateRes> updateChecklist(
-            @RequestBody ChecklistUpdateReq checklistUpdateReq) {
+            @RequestBody ChecklistUpdateReq checklistUpdateReq,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        checklistUpdateReq.setUsername(userDetails.getUsername());
         return RestResponse.success(checklistService.updateChecklist(checklistUpdateReq));
     }
 

--- a/src/main/java/com/vt/valuetogether/domain/checklist/controller/ChecklistController.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/controller/ChecklistController.java
@@ -9,6 +9,8 @@ import com.vt.valuetogether.domain.checklist.dto.response.ChecklistUpdateRes;
 import com.vt.valuetogether.domain.checklist.service.ChecklistService;
 import com.vt.valuetogether.global.response.RestResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,7 +26,9 @@ public class ChecklistController {
 
     @PostMapping
     public RestResponse<ChecklistSaveRes> saveChecklist(
-            @RequestBody ChecklistSaveReq checklistSaveReq) {
+            @RequestBody ChecklistSaveReq checklistSaveReq,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        checklistSaveReq.setUsername(userDetails.getUsername());
         return RestResponse.success(checklistService.saveChecklist(checklistSaveReq));
     }
 

--- a/src/main/java/com/vt/valuetogether/domain/checklist/dto/request/ChecklistDeleteReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/dto/request/ChecklistDeleteReq.java
@@ -4,11 +4,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChecklistDeleteReq {
     private Long checklistId;
+    private String username;
 
     @Builder
     private ChecklistDeleteReq(Long checklistId) {

--- a/src/main/java/com/vt/valuetogether/domain/checklist/dto/request/ChecklistSaveReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/dto/request/ChecklistSaveReq.java
@@ -4,12 +4,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChecklistSaveReq {
     private Long cardId;
     private String title;
+    private String username;
 
     @Builder
     private ChecklistSaveReq(Long cardId, String title) {

--- a/src/main/java/com/vt/valuetogether/domain/checklist/dto/request/ChecklistUpdateReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/dto/request/ChecklistUpdateReq.java
@@ -4,12 +4,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChecklistUpdateReq {
     private Long checklistId;
     private String title;
+    private String username;
 
     @Builder
     private ChecklistUpdateReq(Long checklistId, String title) {

--- a/src/main/java/com/vt/valuetogether/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -45,9 +45,7 @@ public class ChecklistServiceImpl implements ChecklistService {
     @Transactional
     public ChecklistUpdateRes updateChecklist(ChecklistUpdateReq checklistUpdateReq) {
         User user = getUserByUsername(checklistUpdateReq.getUsername());
-        Checklist prevChecklist =
-                checklistRepository.findByChecklistId(checklistUpdateReq.getChecklistId());
-        ChecklistValidator.validate(prevChecklist);
+        Checklist prevChecklist = getChecklistById(checklistUpdateReq.getChecklistId());
         TeamRoleValidator.checkIsTeamMember(
                 prevChecklist.getCard().getCategory().getTeam().getTeamRoleList(), user);
         checklistRepository.save(
@@ -63,9 +61,7 @@ public class ChecklistServiceImpl implements ChecklistService {
     @Transactional
     public ChecklistDeleteRes deleteChecklist(ChecklistDeleteReq checklistDeleteReq) {
         User user = getUserByUsername(checklistDeleteReq.getUsername());
-        Checklist checklist =
-                checklistRepository.findByChecklistId(checklistDeleteReq.getChecklistId());
-        ChecklistValidator.validate(checklist);
+        Checklist checklist = getChecklistById(checklistDeleteReq.getChecklistId());
         TeamRoleValidator.checkIsTeamMember(
                 checklist.getCard().getCategory().getTeam().getTeamRoleList(), user);
         checklistRepository.delete(checklist);
@@ -76,5 +72,11 @@ public class ChecklistServiceImpl implements ChecklistService {
         User user = userRepository.findByUsername(username);
         UserValidator.validate(user);
         return user;
+    }
+
+    private Checklist getChecklistById(Long checklistId) {
+        Checklist checklist = checklistRepository.findByChecklistId(checklistId);
+        ChecklistValidator.validate(checklist);
+        return checklist;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -12,27 +12,37 @@ import com.vt.valuetogether.domain.checklist.entity.Checklist;
 import com.vt.valuetogether.domain.checklist.repository.ChecklistRepository;
 import com.vt.valuetogether.domain.checklist.service.ChecklistService;
 import com.vt.valuetogether.domain.checklist.service.ChecklistServiceMapper;
+import com.vt.valuetogether.domain.user.entity.User;
+import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.global.validator.CardValidator;
 import com.vt.valuetogether.global.validator.ChecklistValidator;
+import com.vt.valuetogether.global.validator.TeamRoleValidator;
+import com.vt.valuetogether.global.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ChecklistServiceImpl implements ChecklistService {
     private final ChecklistRepository checklistRepository;
     private final CardRepository cardRepository;
+    private final UserRepository userRepository;
 
     @Override
+    @Transactional
     public ChecklistSaveRes saveChecklist(ChecklistSaveReq checklistSaveReq) {
+        User user = getUserByUsername(checklistSaveReq.getUsername());
         Card card = cardRepository.findByCardId(checklistSaveReq.getCardId());
         CardValidator.validate(card);
+        TeamRoleValidator.checkIsTeamMember(card.getCategory().getTeam().getTeamRoleList(), user);
         return ChecklistServiceMapper.INSTANCE.toChecklistSaveRes(
                 checklistRepository.save(
                         Checklist.builder().card(card).title(checklistSaveReq.getTitle()).build()));
     }
 
     @Override
+    @Transactional
     public ChecklistUpdateRes updateChecklist(ChecklistUpdateReq checklistUpdateReq) {
         Checklist prevChecklist =
                 checklistRepository.findByChecklistId(checklistUpdateReq.getChecklistId());
@@ -47,11 +57,18 @@ public class ChecklistServiceImpl implements ChecklistService {
     }
 
     @Override
+    @Transactional
     public ChecklistDeleteRes deleteChecklist(ChecklistDeleteReq checklistDeleteReq) {
         Checklist checklist =
                 checklistRepository.findByChecklistId(checklistDeleteReq.getChecklistId());
         ChecklistValidator.validate(checklist);
         checklistRepository.delete(checklist);
         return new ChecklistDeleteRes();
+    }
+
+    private User getUserByUsername(String username) {
+        User user = userRepository.findByUsername(username);
+        UserValidator.validate(user);
+        return user;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -44,9 +44,12 @@ public class ChecklistServiceImpl implements ChecklistService {
     @Override
     @Transactional
     public ChecklistUpdateRes updateChecklist(ChecklistUpdateReq checklistUpdateReq) {
+        User user = getUserByUsername(checklistUpdateReq.getUsername());
         Checklist prevChecklist =
                 checklistRepository.findByChecklistId(checklistUpdateReq.getChecklistId());
         ChecklistValidator.validate(prevChecklist);
+        TeamRoleValidator.checkIsTeamMember(
+                prevChecklist.getCard().getCategory().getTeam().getTeamRoleList(), user);
         checklistRepository.save(
                 Checklist.builder()
                         .checklistId(checklistUpdateReq.getChecklistId())

--- a/src/main/java/com/vt/valuetogether/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -62,9 +62,12 @@ public class ChecklistServiceImpl implements ChecklistService {
     @Override
     @Transactional
     public ChecklistDeleteRes deleteChecklist(ChecklistDeleteReq checklistDeleteReq) {
+        User user = getUserByUsername(checklistDeleteReq.getUsername());
         Checklist checklist =
                 checklistRepository.findByChecklistId(checklistDeleteReq.getChecklistId());
         ChecklistValidator.validate(checklist);
+        TeamRoleValidator.checkIsTeamMember(
+                checklist.getCard().getCategory().getTeam().getTeamRoleList(), user);
         checklistRepository.delete(checklist);
         return new ChecklistDeleteRes();
     }

--- a/src/test/java/com/vt/valuetogether/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/controller/ChecklistControllerTest.java
@@ -57,7 +57,8 @@ class ChecklistControllerTest extends BaseMvcTest {
                 .perform(
                         patch("/api/v1/checklists")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(checklistUpdateReq)))
+                                .content(objectMapper.writeValueAsString(checklistUpdateReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/controller/ChecklistControllerTest.java
@@ -38,7 +38,8 @@ class ChecklistControllerTest extends BaseMvcTest {
                 .perform(
                         post("/api/v1/checklists")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(checklistSaveReq)))
+                                .content(objectMapper.writeValueAsString(checklistSaveReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/controller/ChecklistControllerTest.java
@@ -75,7 +75,8 @@ class ChecklistControllerTest extends BaseMvcTest {
                 .perform(
                         delete("/api/v1/checklists")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(checklistDeleteReq)))
+                                .content(objectMapper.writeValueAsString(checklistDeleteReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/checklist/service/ChecklistServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/service/ChecklistServiceImplTest.java
@@ -119,12 +119,14 @@ class ChecklistServiceImplTest implements ChecklistTest, UserTest, TeamRoleTest 
         Long checklistId = 1L;
         ChecklistDeleteReq checklistDeleteReq =
                 ChecklistDeleteReq.builder().checklistId(checklistId).build();
-        when(checklistRepository.findByChecklistId(any())).thenReturn(TEST_CHECKLIST);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(checklistRepository.findByChecklistId(any())).thenReturn(checklist);
 
         // when
         checklistService.deleteChecklist(checklistDeleteReq);
 
         // then
+        verify(userRepository).findByUsername(any());
         verify(checklistRepository).findByChecklistId(any());
         verify(checklistRepository).delete(any());
     }

--- a/src/test/java/com/vt/valuetogether/domain/checklist/service/ChecklistServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/service/ChecklistServiceImplTest.java
@@ -99,13 +99,15 @@ class ChecklistServiceImplTest implements ChecklistTest, UserTest, TeamRoleTest 
         String title = "updatedTitle";
         ChecklistUpdateReq checklistUpdateReq =
                 ChecklistUpdateReq.builder().checklistId(checklistId).title(title).build();
-        when(checklistRepository.findByChecklistId(any())).thenReturn(TEST_CHECKLIST);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(checklistRepository.findByChecklistId(any())).thenReturn(checklist);
         when(checklistRepository.save(any())).thenReturn(TEST_UPDATED_CHECKLIST);
 
         // when
         checklistService.updateChecklist(checklistUpdateReq);
 
         // then
+        verify(userRepository).findByUsername(any());
         verify(checklistRepository).findByChecklistId(any());
         verify(checklistRepository).save(any());
     }

--- a/src/test/java/com/vt/valuetogether/domain/checklist/service/ChecklistServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/checklist/service/ChecklistServiceImplTest.java
@@ -4,13 +4,22 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.vt.valuetogether.domain.card.entity.Card;
 import com.vt.valuetogether.domain.card.repository.CardRepository;
+import com.vt.valuetogether.domain.category.entity.Category;
 import com.vt.valuetogether.domain.checklist.dto.request.ChecklistDeleteReq;
 import com.vt.valuetogether.domain.checklist.dto.request.ChecklistSaveReq;
 import com.vt.valuetogether.domain.checklist.dto.request.ChecklistUpdateReq;
+import com.vt.valuetogether.domain.checklist.entity.Checklist;
 import com.vt.valuetogether.domain.checklist.repository.ChecklistRepository;
 import com.vt.valuetogether.domain.checklist.service.impl.ChecklistServiceImpl;
+import com.vt.valuetogether.domain.team.entity.Team;
+import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.test.ChecklistTest;
+import com.vt.valuetogether.test.TeamRoleTest;
+import com.vt.valuetogether.test.UserTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,11 +28,49 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class ChecklistServiceImplTest implements ChecklistTest {
+class ChecklistServiceImplTest implements ChecklistTest, UserTest, TeamRoleTest {
     @InjectMocks private ChecklistServiceImpl checklistService;
 
     @Mock private ChecklistRepository checklistRepository;
     @Mock private CardRepository cardRepository;
+    @Mock private UserRepository userRepository;
+    private Category category;
+    private Team team;
+    private Card card;
+    private Checklist checklist;
+
+    @BeforeEach
+    void setUp() {
+        team =
+                Team.builder()
+                        .teamId(TEST_TEAM_ID)
+                        .teamName(TEST_TEAM_NAME)
+                        .teamDescription(TEST_TEAM_DESCRIPTION)
+                        .backgroundColor(TEST_BACKGROUND_COLOR)
+                        .isDeleted(TEST_TEAM_IS_DELETED)
+                        .teamRoleList(List.of(TEST_TEAM_ROLE))
+                        .build();
+        category =
+                Category.builder()
+                        .categoryId(TEST_CATEGORY_ID)
+                        .name(TEST_CATEGORY_NAME)
+                        .sequence(TEST_CATEGORY_SEQUENCE)
+                        .isDeleted(TEST_CATEGORY_IS_DELETED)
+                        .team(team)
+                        .build();
+        card =
+                Card.builder()
+                        .cardId(TEST_CARD_ID)
+                        .name(TEST_NAME)
+                        .description(TEST_DESCRIPTION)
+                        .fileUrl(TEST_FILE_URL)
+                        .sequence(TEST_SEQUENCE)
+                        .deadline(TEST_DEADLINE)
+                        .category(category)
+                        .build();
+        checklist =
+                Checklist.builder().checklistId(TEST_CHECKLIST_ID).title(TEST_TITLE).card(card).build();
+    }
 
     @Test
     @DisplayName("checklist 저장 테스트")
@@ -31,13 +78,15 @@ class ChecklistServiceImplTest implements ChecklistTest {
         // given
         String title = "title";
         ChecklistSaveReq checklistSaveReq = ChecklistSaveReq.builder().title(title).build();
-        when(cardRepository.findByCardId(any())).thenReturn(TEST_CARD);
-        when(checklistRepository.save(any())).thenReturn(TEST_CHECKLIST);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(cardRepository.findByCardId(any())).thenReturn(card);
+        when(checklistRepository.save(any())).thenReturn(checklist);
 
         // when
         checklistService.saveChecklist(checklistSaveReq);
 
         // then
+        verify(userRepository).findByUsername(any());
         verify(cardRepository).findByCardId(any());
         verify(checklistRepository).save(any());
     }


### PR DESCRIPTION
## 개요
체크리스트 api 요청 시 팀의 멤버인지 확인하는 로직을 추가합니다.

## 작업사항
- 체크리스트 저장 시 팀의 멤버인지 확인
- 체크리스트 수정 시 팀의 멤버인지 확인
- 체크리스트 삭제 시 팀의 멤버인지 확인
- 관련된 테스트코드 수정

## 관련 이슈
- close #168 
