### PR TITLE
할일 api 요청 시 팀의 멤버인지 확인 로직 추가

### DIFF
--- a/src/main/java/com/vt/valuetogether/domain/task/controller/TaskController.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/controller/TaskController.java
@@ -9,6 +9,8 @@ import com.vt.valuetogether.domain.task.dto.response.TaskUpdateRes;
 import com.vt.valuetogether.domain.task.service.TaskService;
 import com.vt.valuetogether.global.response.RestResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,7 +25,9 @@ public class TaskController {
     private final TaskService taskService;
 
     @PostMapping
-    public RestResponse<TaskSaveRes> saveTask(@RequestBody TaskSaveReq taskSaveReq) {
+    public RestResponse<TaskSaveRes> saveTask(
+            @RequestBody TaskSaveReq taskSaveReq, @AuthenticationPrincipal UserDetails userDetails) {
+        taskSaveReq.setUsername(userDetails.getUsername());
         return RestResponse.success(taskService.saveTask(taskSaveReq));
     }
 

--- a/src/main/java/com/vt/valuetogether/domain/task/controller/TaskController.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/controller/TaskController.java
@@ -39,7 +39,9 @@ public class TaskController {
     }
 
     @DeleteMapping
-    public RestResponse<TaskDeleteRes> deleteTask(@RequestBody TaskDeleteReq taskDeleteReq) {
+    public RestResponse<TaskDeleteRes> deleteTask(
+            @RequestBody TaskDeleteReq taskDeleteReq, @AuthenticationPrincipal UserDetails userDetails) {
+        taskDeleteReq.setUsername(userDetails.getUsername());
         return RestResponse.success(taskService.deleteTask(taskDeleteReq));
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/task/controller/TaskController.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/controller/TaskController.java
@@ -32,7 +32,9 @@ public class TaskController {
     }
 
     @PatchMapping
-    public RestResponse<TaskUpdateRes> updateTask(@RequestBody TaskUpdateReq taskUpdateReq) {
+    public RestResponse<TaskUpdateRes> updateTask(
+            @RequestBody TaskUpdateReq taskUpdateReq, @AuthenticationPrincipal UserDetails userDetails) {
+        taskUpdateReq.setUsername(userDetails.getUsername());
         return RestResponse.success(taskService.updateTask(taskUpdateReq));
     }
 

--- a/src/main/java/com/vt/valuetogether/domain/task/dto/request/TaskDeleteReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/dto/request/TaskDeleteReq.java
@@ -4,11 +4,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TaskDeleteReq {
     private Long taskId;
+    private String username;
 
     @Builder
     private TaskDeleteReq(Long taskId) {

--- a/src/main/java/com/vt/valuetogether/domain/task/dto/request/TaskSaveReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/dto/request/TaskSaveReq.java
@@ -4,12 +4,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TaskSaveReq {
     private Long checklistId;
     private String content;
+    private String username;
 
     @Builder
     private TaskSaveReq(Long checklistId, String content) {

--- a/src/main/java/com/vt/valuetogether/domain/task/dto/request/TaskUpdateReq.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/dto/request/TaskUpdateReq.java
@@ -4,13 +4,16 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TaskUpdateReq {
     private Long taskId;
     private String content;
     private Boolean isCompleted;
+    private String username;
 
     @Builder
     private TaskUpdateReq(Long taskId, String content, Boolean isCompleted) {

--- a/src/main/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImpl.java
@@ -50,10 +50,9 @@ public class TaskServiceImpl implements TaskService {
     @Override
     @Transactional
     public TaskUpdateRes updateTask(TaskUpdateReq taskUpdateReq) {
-        User user = getUserByUsername(taskUpdateReq.getUsername());
         TaskValidator.validate(taskUpdateReq);
-        Task prevTask = taskRepository.findByTaskId(taskUpdateReq.getTaskId());
-        TaskValidator.validate(prevTask);
+        User user = getUserByUsername(taskUpdateReq.getUsername());
+        Task prevTask = getTaskById(taskUpdateReq.getTaskId());
         TeamRoleValidator.checkIsTeamMember(
                 prevTask.getChecklist().getCard().getCategory().getTeam().getTeamRoleList(), user);
         taskRepository.save(
@@ -70,8 +69,7 @@ public class TaskServiceImpl implements TaskService {
     @Transactional
     public TaskDeleteRes deleteTask(TaskDeleteReq taskDeleteReq) {
         User user = getUserByUsername(taskDeleteReq.getUsername());
-        Task task = taskRepository.findByTaskId(taskDeleteReq.getTaskId());
-        TaskValidator.validate(task);
+        Task task = getTaskById(taskDeleteReq.getTaskId());
         TeamRoleValidator.checkIsTeamMember(
                 task.getChecklist().getCard().getCategory().getTeam().getTeamRoleList(), user);
         taskRepository.delete(task);
@@ -82,5 +80,11 @@ public class TaskServiceImpl implements TaskService {
         User user = userRepository.findByUsername(username);
         UserValidator.validate(user);
         return user;
+    }
+
+    private Task getTaskById(Long taskId) {
+        Task task = taskRepository.findByTaskId(taskId);
+        TaskValidator.validate(task);
+        return task;
     }
 }

--- a/src/main/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImpl.java
@@ -69,8 +69,11 @@ public class TaskServiceImpl implements TaskService {
     @Override
     @Transactional
     public TaskDeleteRes deleteTask(TaskDeleteReq taskDeleteReq) {
+        User user = getUserByUsername(taskDeleteReq.getUsername());
         Task task = taskRepository.findByTaskId(taskDeleteReq.getTaskId());
         TaskValidator.validate(task);
+        TeamRoleValidator.checkIsTeamMember(
+                task.getChecklist().getCard().getCategory().getTeam().getTeamRoleList(), user);
         taskRepository.delete(task);
         return new TaskDeleteRes();
     }

--- a/src/main/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImpl.java
@@ -50,9 +50,12 @@ public class TaskServiceImpl implements TaskService {
     @Override
     @Transactional
     public TaskUpdateRes updateTask(TaskUpdateReq taskUpdateReq) {
+        User user = getUserByUsername(taskUpdateReq.getUsername());
         TaskValidator.validate(taskUpdateReq);
         Task prevTask = taskRepository.findByTaskId(taskUpdateReq.getTaskId());
         TaskValidator.validate(prevTask);
+        TeamRoleValidator.checkIsTeamMember(
+                prevTask.getChecklist().getCard().getCategory().getTeam().getTeamRoleList(), user);
         taskRepository.save(
                 Task.builder()
                         .taskId(prevTask.getTaskId())

--- a/src/main/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImpl.java
@@ -12,22 +12,32 @@ import com.vt.valuetogether.domain.task.entity.Task;
 import com.vt.valuetogether.domain.task.repository.TaskRepository;
 import com.vt.valuetogether.domain.task.service.TaskService;
 import com.vt.valuetogether.domain.task.service.TaskServiceMapper;
+import com.vt.valuetogether.domain.user.entity.User;
+import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.global.validator.ChecklistValidator;
 import com.vt.valuetogether.global.validator.TaskValidator;
+import com.vt.valuetogether.global.validator.TeamRoleValidator;
+import com.vt.valuetogether.global.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class TaskServiceImpl implements TaskService {
     private final ChecklistRepository checklistRepository;
     private final TaskRepository taskRepository;
+    private final UserRepository userRepository;
 
     @Override
+    @Transactional
     public TaskSaveRes saveTask(TaskSaveReq taskSaveReq) {
         TaskValidator.validate(taskSaveReq);
+        User user = getUserByUsername(taskSaveReq.getUsername());
         Checklist checklist = checklistRepository.findByChecklistId(taskSaveReq.getChecklistId());
         ChecklistValidator.validate(checklist);
+        TeamRoleValidator.checkIsTeamMember(
+                checklist.getCard().getCategory().getTeam().getTeamRoleList(), user);
         return TaskServiceMapper.INSTANCE.toTaskSaveRes(
                 taskRepository.save(
                         Task.builder()
@@ -38,6 +48,7 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
+    @Transactional
     public TaskUpdateRes updateTask(TaskUpdateReq taskUpdateReq) {
         TaskValidator.validate(taskUpdateReq);
         Task prevTask = taskRepository.findByTaskId(taskUpdateReq.getTaskId());
@@ -53,10 +64,17 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
+    @Transactional
     public TaskDeleteRes deleteTask(TaskDeleteReq taskDeleteReq) {
         Task task = taskRepository.findByTaskId(taskDeleteReq.getTaskId());
         TaskValidator.validate(task);
         taskRepository.delete(task);
         return new TaskDeleteRes();
+    }
+
+    private User getUserByUsername(String username) {
+        User user = userRepository.findByUsername(username);
+        UserValidator.validate(user);
+        return user;
     }
 }

--- a/src/test/java/com/vt/valuetogether/domain/task/controller/TaskControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/task/controller/TaskControllerTest.java
@@ -77,7 +77,8 @@ class TaskControllerTest extends BaseMvcTest {
                 .perform(
                         delete("/api/v1/tasks")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(taskDeleteReq)))
+                                .content(objectMapper.writeValueAsString(taskDeleteReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/task/controller/TaskControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/task/controller/TaskControllerTest.java
@@ -40,7 +40,8 @@ class TaskControllerTest extends BaseMvcTest {
                 .perform(
                         post("/api/v1/tasks")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(taskSaveReq)))
+                                .content(objectMapper.writeValueAsString(taskSaveReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/task/controller/TaskControllerTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/task/controller/TaskControllerTest.java
@@ -60,7 +60,8 @@ class TaskControllerTest extends BaseMvcTest {
                 .perform(
                         patch("/api/v1/tasks")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(taskUpdateReq)))
+                                .content(objectMapper.writeValueAsString(taskUpdateReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImplTest.java
@@ -129,12 +129,14 @@ class TaskServiceImplTest implements TaskTest, UserTest, TeamRoleTest {
         // given
         Long taskId = 1L;
         TaskDeleteReq taskDeleteReq = TaskDeleteReq.builder().taskId(taskId).build();
-        when(taskRepository.findByTaskId(any())).thenReturn(TEST_TASK);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(taskRepository.findByTaskId(any())).thenReturn(task);
 
         // when
         taskService.deleteTask(taskDeleteReq);
 
         // then
+        verify(userRepository).findByUsername(any());
         verify(taskRepository).findByTaskId(any());
         verify(taskRepository).delete(any());
     }

--- a/src/test/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImplTest.java
@@ -4,12 +4,22 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.vt.valuetogether.domain.card.entity.Card;
+import com.vt.valuetogether.domain.category.entity.Category;
+import com.vt.valuetogether.domain.checklist.entity.Checklist;
 import com.vt.valuetogether.domain.checklist.repository.ChecklistRepository;
 import com.vt.valuetogether.domain.task.dto.request.TaskDeleteReq;
 import com.vt.valuetogether.domain.task.dto.request.TaskSaveReq;
 import com.vt.valuetogether.domain.task.dto.request.TaskUpdateReq;
+import com.vt.valuetogether.domain.task.entity.Task;
 import com.vt.valuetogether.domain.task.repository.TaskRepository;
+import com.vt.valuetogether.domain.team.entity.Team;
+import com.vt.valuetogether.domain.user.repository.UserRepository;
 import com.vt.valuetogether.test.TaskTest;
+import com.vt.valuetogether.test.TeamRoleTest;
+import com.vt.valuetogether.test.UserTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,11 +28,57 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class TaskServiceImplTest implements TaskTest {
+class TaskServiceImplTest implements TaskTest, UserTest, TeamRoleTest {
     @InjectMocks private TaskServiceImpl taskService;
 
     @Mock private TaskRepository taskRepository;
     @Mock private ChecklistRepository checklistRepository;
+    @Mock private UserRepository userRepository;
+    private Category category;
+    private Team team;
+    private Card card;
+    private Checklist checklist;
+    private Task task;
+
+    @BeforeEach
+    void setUp() {
+        team =
+                Team.builder()
+                        .teamId(TEST_TEAM_ID)
+                        .teamName(TEST_TEAM_NAME)
+                        .teamDescription(TEST_TEAM_DESCRIPTION)
+                        .backgroundColor(TEST_BACKGROUND_COLOR)
+                        .isDeleted(TEST_TEAM_IS_DELETED)
+                        .teamRoleList(List.of(TEST_TEAM_ROLE))
+                        .build();
+        category =
+                Category.builder()
+                        .categoryId(TEST_CATEGORY_ID)
+                        .name(TEST_CATEGORY_NAME)
+                        .sequence(TEST_CATEGORY_SEQUENCE)
+                        .isDeleted(TEST_CATEGORY_IS_DELETED)
+                        .team(team)
+                        .build();
+        card =
+                Card.builder()
+                        .cardId(TEST_CARD_ID)
+                        .name(TEST_NAME)
+                        .description(TEST_DESCRIPTION)
+                        .fileUrl(TEST_FILE_URL)
+                        .sequence(TEST_SEQUENCE)
+                        .deadline(TEST_DEADLINE)
+                        .category(category)
+                        .build();
+        checklist =
+                Checklist.builder().checklistId(TEST_CHECKLIST_ID).title(TEST_TITLE).card(card).build();
+        task =
+                Task.builder()
+                        .taskId(TEST_TASK_ID)
+                        .content(TEST_CONTENT)
+                        .isCompleted(TEST_IS_COMPLETED)
+                        .checklist(checklist)
+                        .build();
+    }
 
     @Test
     @DisplayName("task 저장 테스트")
@@ -32,8 +88,9 @@ class TaskServiceImplTest implements TaskTest {
         String content = "content";
         TaskSaveReq taskSaveReq =
                 TaskSaveReq.builder().checklistId(checklistId).content(content).build();
-        when(checklistRepository.findByChecklistId(any())).thenReturn(TEST_CHECKLIST);
-        when(taskRepository.save(any())).thenReturn(TEST_TASK);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(checklistRepository.findByChecklistId(any())).thenReturn(checklist);
+        when(taskRepository.save(any())).thenReturn(task);
 
         // when
         taskService.saveTask(taskSaveReq);

--- a/src/test/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/task/service/impl/TaskServiceImplTest.java
@@ -96,6 +96,7 @@ class TaskServiceImplTest implements TaskTest, UserTest, TeamRoleTest {
         taskService.saveTask(taskSaveReq);
 
         // then
+        verify(userRepository).findByUsername(any());
         verify(checklistRepository).findByChecklistId(any());
         verify(taskRepository).save(any());
     }
@@ -109,13 +110,15 @@ class TaskServiceImplTest implements TaskTest, UserTest, TeamRoleTest {
         Boolean isCompleted = true;
         TaskUpdateReq taskUpdateReq =
                 TaskUpdateReq.builder().taskId(taskId).content(content).isCompleted(isCompleted).build();
-        when(taskRepository.findByTaskId(any())).thenReturn(TEST_TASK);
+        when(userRepository.findByUsername(any())).thenReturn(TEST_USER);
+        when(taskRepository.findByTaskId(any())).thenReturn(task);
         when(taskRepository.save(any())).thenReturn(TEST_UPDATED_TASK);
 
         // when
         taskService.updateTask(taskUpdateReq);
 
         // then
+        verify(userRepository).findByUsername(any());
         verify(taskRepository).findByTaskId(any());
         verify(taskRepository).save(any());
     }


### PR DESCRIPTION
## 개요
할일 api 요청 시 팀의 멤버인지 확인하는 로직을 추가합니다.

## 작업사항
- 할일 저장 시 팀의 멤버인지 확인
- 할일 수정 시 팀의 멤버인지 확인
- 할일 삭제 시 팀의 멤버인지 확인
- 관련된 테스트코드 수정

## 관련 이슈
- close #169 
