### PR TITLE
invite code service 테스트코드 추가

### DIFF
--- a/src/test/java/com/vt/valuetogether/domain/user/service/impl/InviteCodeServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/user/service/impl/InviteCodeServiceImplTest.java
@@ -36,4 +36,20 @@ class InviteCodeServiceImplTest implements InviteCodeTest {
         assertThat(inviteCode.getTeamId()).isEqualTo(TEST_TEAM_ID);
         verify(inviteRepository).findById(any());
     }
+
+    @Test
+    @DisplayName("inviteCode 저장 테스트")
+    void invite_code_저장() {
+        // given
+        when(inviteRepository.save(any())).thenReturn(TEST_INVITE_CODE);
+
+        // when
+        InviteCode inviteCode = inviteCodeService.save(TEST_INVITE_CODE);
+
+        // then
+        assertThat(inviteCode.getCode()).isEqualTo(TEST_INVITE_CODE_CODE);
+        assertThat(inviteCode.getUserId()).isEqualTo(TEST_USER_ID);
+        assertThat(inviteCode.getTeamId()).isEqualTo(TEST_TEAM_ID);
+        verify(inviteRepository).save(any());
+    }
 }

--- a/src/test/java/com/vt/valuetogether/domain/user/service/impl/InviteCodeServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/user/service/impl/InviteCodeServiceImplTest.java
@@ -1,0 +1,39 @@
+package com.vt.valuetogether.domain.user.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vt.valuetogether.domain.user.entity.InviteCode;
+import com.vt.valuetogether.domain.user.repository.InviteRepository;
+import com.vt.valuetogether.test.InviteCodeTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InviteCodeServiceImplTest implements InviteCodeTest {
+    @InjectMocks private InviteCodeServiceImpl inviteCodeService;
+
+    @Mock private InviteRepository inviteRepository;
+
+    @Test
+    @DisplayName("code로 inviteCode 조회 테스트")
+    void code_invite_code_조회() {
+        // given
+        when(inviteRepository.findById(any())).thenReturn(TEST_INVITE_CODE);
+
+        // when
+        InviteCode inviteCode = inviteCodeService.findById(TEST_INVITE_CODE_CODE);
+
+        // then
+        assertThat(inviteCode.getCode()).isEqualTo(TEST_INVITE_CODE_CODE);
+        assertThat(inviteCode.getUserId()).isEqualTo(TEST_USER_ID);
+        assertThat(inviteCode.getTeamId()).isEqualTo(TEST_TEAM_ID);
+        verify(inviteRepository).findById(any());
+    }
+}

--- a/src/test/java/com/vt/valuetogether/domain/user/service/impl/InviteCodeServiceImplTest.java
+++ b/src/test/java/com/vt/valuetogether/domain/user/service/impl/InviteCodeServiceImplTest.java
@@ -52,4 +52,16 @@ class InviteCodeServiceImplTest implements InviteCodeTest {
         assertThat(inviteCode.getTeamId()).isEqualTo(TEST_TEAM_ID);
         verify(inviteRepository).save(any());
     }
+
+    @Test
+    @DisplayName("inviteCode 삭제 테스트")
+    void invite_code_삭제() {
+        // given
+
+        // when
+        inviteCodeService.deleteById(TEST_INVITE_CODE_CODE);
+
+        // then
+        verify(inviteRepository).deleteById(any());
+    }
 }

--- a/src/test/java/com/vt/valuetogether/test/InviteCodeTest.java
+++ b/src/test/java/com/vt/valuetogether/test/InviteCodeTest.java
@@ -1,0 +1,15 @@
+package com.vt.valuetogether.test;
+
+import com.vt.valuetogether.domain.user.entity.InviteCode;
+import java.util.UUID;
+
+public interface InviteCodeTest extends UserTest, TeamTest {
+    String TEST_INVITE_CODE_CODE = UUID.randomUUID().toString().substring(0, 8);
+
+    InviteCode TEST_INVITE_CODE =
+            InviteCode.builder()
+                    .code(TEST_INVITE_CODE_CODE)
+                    .userId(TEST_USER_ID)
+                    .teamId(TEST_TEAM_ID)
+                    .build();
+}


### PR DESCRIPTION
## 개요
invite code service layer 로직 테스트코드를 추가합니다.

## 작업사항
- code로 inviteCode 조회 테스트코드 추가
- inviteCode 저장 테스트코드 추가
- inviteCode 삭제 테스트코드 추가

## 관련 이슈
- close #177 
